### PR TITLE
ci: add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pre-commit hook via simple-git-hooks and lint-staged
 - Chrome Web Store description file (`description.txt`)
 
+### Security
+
+- Added explicit read-only permissions to CI workflow to restrict GITHUB_TOKEN scope
+
 ### Changed
 
 - Replaced Chrome Web Store badge with high-resolution version for Retina displays


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` to the CI workflow, restricting the `GITHUB_TOKEN` to read-only access
- Follows the principle of least privilege as recommended by GitHub's security best practices
- Resolves CodeQL code scanning alert #1

## Test plan

- [ ] Verify CI workflow still passes on this PR (checkout, install, lint, test, build all work with read-only permissions)