### PR TITLE
fix(a11y): use semantic button elements for sort controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Sort buttons use semantic `<button>` elements with `aria-pressed` for accessibility
-- Added visible `:focus-visible` outline for keyboard navigation of sort buttons
-
 ### Added
 
 - ESLint with TypeScript and React Hooks plugins
@@ -21,12 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Playwright-based screenshot generator for Chrome Web Store images (`bun run screenshots`)
 - New screenshots: default order and compact/responsive mode
 
-### Security
-
-- Added explicit read-only permissions to CI workflow to restrict GITHUB_TOKEN scope
-
 ### Changed
 
+- Sort buttons use semantic `<button>` elements with `aria-pressed` for accessibility
+- Added visible `:focus-visible` outline for keyboard navigation of sort buttons
 - Replaced Chrome Web Store badge with high-resolution version for Retina displays
 - Updated dev dependencies to latest versions
 - Improved README with badges, features section, and cleaner layout
@@ -35,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidated CSS class constants into `CSS_CLASSES`, `CSS_SELECTORS`, and `SORT_OPTIONS` objects
 - Added `data-sort` attribute to sort buttons for programmatic access
 - Regenerated Chrome Web Store screenshots with current HN content and optimized file sizes
+
+### Security
+
+- Added explicit read-only permissions to CI workflow to restrict GITHUB_TOKEN scope
 
 ## [2.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Sort buttons use semantic `<button>` elements with `aria-pressed` for accessibility
+- Added visible `:focus-visible` outline for keyboard navigation of sort buttons
+
 ### Added
 
 - ESLint with TypeScript and React Hooks plugins

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Use a scope when relevant: `feat(shortcuts): add vim-style navigation`
 
 ## Changelog
 
-The changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with these categories: Added, Changed, Deprecated, Removed, Fixed, Security.
+The changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with these categories (in order): Added, Changed, Deprecated, Removed, Fixed, Security. Each category must appear at most once per release section — always append to an existing category rather than creating a duplicate.
 
 ## Chrome Web Store Description
 

--- a/app/components/SortButton.tsx
+++ b/app/components/SortButton.tsx
@@ -22,14 +22,16 @@ const SortButton = ({ sortOption, activeSort, setActiveSort }: ControlPanelButto
   }, [sortBy, isActive, setActiveSort]);
 
   return (
-    <span
+    <button
+      type="button"
       onClick={updateActiveSort}
       className={cssClasses}
       data-sort={sortBy}
+      aria-pressed={isActive}
       title={sortBy === 'default' ? 'Original sort order' : `Sort by ${sortBy}`}>
       <span className={CSS_CLASSES.BTN_TEXT}>{text}</span>
       <span className={CSS_CLASSES.BTN_SHORTCUT}>{shortcut}</span>
-    </span>
+    </button>
   );
 };
 

--- a/content.css
+++ b/content.css
@@ -10,9 +10,16 @@
 }
 
 .hns-btn {
+  all: unset;
   cursor: pointer;
   display: inline-block;
   margin: 0 5px;
+}
+
+.hns-btn:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 .hns-btn-text {


### PR DESCRIPTION
## Summary

- Replaced `<span onClick>` with `<button type="button">` in `SortButton` for proper semantic HTML and built-in keyboard support (Enter/Space activation, tab focusability)
- Added `aria-pressed` attribute to convey active/toggle state to assistive technology
- Added `all: unset` to reset default button styling while preserving existing appearance
- Added `:focus-visible` outline rule for visible keyboard focus indication

## Test plan

- [x] All 94 existing tests pass
- [x] ESLint and Prettier checks pass
- [x] Verify sort buttons are focusable via Tab key in Chrome
- [x] Verify Enter/Space activates sort buttons
- [x] Verify `aria-pressed` toggles correctly (inspect with DevTools/screen reader)
- [x] Verify focus outline appears on keyboard navigation but not on mouse click
- [x] Visual regression: buttons look identical to before