### PR TITLE
chore: bump version to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.3.0]
 
 ### Added
 

--- a/description.txt
+++ b/description.txt
@@ -13,6 +13,7 @@ Keyboard shortcuts:
 P = Points | T = Time | C = Comments | D = Default
 
 Changelog:
+v2.3 - New post indicators, popup settings, cross-device sync
 v2.2 - Added keyboard shortcuts, Vimium compatibility
 v2.1 - Active sort column highlighting, performance improvements
 v2.0 - Complete rewrite with TypeScript, persistent preferences

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hacked_news_sorted",
   "displayName": "Hacker News Sorted",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Sort Hacker News your way — by points, time, or comments — instantly.",
   "author": "Leonid Svyatov <leonid@svyatov.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version from 2.2.0 to 2.3.0 in package.json
- Update CHANGELOG.md: rename [Unreleased] to [2.3.0]
- Add v2.3 entry to description.txt for Chrome Web Store

## Test plan
- [x] `bun run lint` passes
- [x] `bun run test` passes (100 tests)