### PR TITLE
ci: add Codecov coverage reporting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,12 @@ jobs:
         run: bun run lint
 
       - name: Run tests
-        run: bun run test
+        run: bun run test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build extension
         run: bun run build

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Chrome Web Store Users](https://img.shields.io/chrome-web-store/users/djkcnbncofmjekhlhemlkinfpkamlkaj)](https://chrome.google.com/webstore/detail/hacker-news-sorted/djkcnbncofmjekhlhemlkinfpkamlkaj)
 [![Chrome Web Store Rating](https://img.shields.io/chrome-web-store/stars/djkcnbncofmjekhlhemlkinfpkamlkaj)](https://chrome.google.com/webstore/detail/hacker-news-sorted/djkcnbncofmjekhlhemlkinfpkamlkaj)
 [![CI](https://img.shields.io/github/actions/workflow/status/svyatov/hacker_news_sorted/main.yml)](https://github.com/svyatov/hacker_news_sorted/actions)
+[![codecov](https://codecov.io/gh/svyatov/hacker_news_sorted/graph/badge.svg)](https://codecov.io/gh/svyatov/hacker_news_sorted)
 [![License](https://img.shields.io/github/license/svyatov/hacker_news_sorted)](https://github.com/svyatov/hacker_news_sorted/blob/main/LICENSE)
 
 Sort [Hacker News](https://news.ycombinator.com) your way — by points, time, or comments — instantly.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     include: ['app/**/*.test.{ts,tsx}'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'html', 'lcov'],
       include: ['app/**/*.{ts,tsx}'],
       exclude: ['app/**/*.test.{ts,tsx}', 'app/__fixtures__/**'],
     },


### PR DESCRIPTION
## Summary
- Add `lcov` reporter to Vitest coverage config for Codecov compatibility
- Run `test:coverage` in CI and upload results via `codecov/codecov-action@v5`
- Add Codecov badge to README

## Test plan
- [ ] CI passes with `test:coverage`
- [ ] Codecov upload step succeeds (requires `CODECOV_TOKEN` secret)
- [ ] Badge renders on README after merge