### PR TITLE
feat(new-posts): add cooldown with opacity fade for new post indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New post indicator cooldown with opacity fade — indicators persist across reloads and fade out over a configurable period (default 60 min, range 10s–24h)
+- Cooldown setting in extension popup (visible when "Highlight new posts" is on)
 - Review prompt: dismissible bar above post table after 7 days or 20 sorts
 - Persistent review link in extension popup
 - Demo video and GIF generation script (`bun run demo`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
 
 ### Popup Entry Point
 
-- `popup.tsx` - Settings popup UI with toggle switch for new-post indicators; shows a warning banner when layout detection fails
+- `popup.tsx` - Settings popup UI with toggle switch for new-post indicators and cooldown number input; shows a warning banner when layout detection fails
 - `popup.css` - Popup styles (toggle switches, layout, warning banner)
 - Uses `@plasmohq/storage` `useStorage` hook for reactive persistence to `chrome.storage.sync`
 
@@ -61,7 +61,7 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
 - `app/utils/parsers.ts` - Extract numeric values (points, time, comments) from info rows
 - `app/utils/sorters.ts` - Sort functions for each sort variant
 - `app/utils/presenters.ts` - DOM manipulation to update table and highlight active sort column
-- `app/utils/newPosts.ts` - New post detection: extracts post IDs from DOM, marks new rows with CSS class, provides `isFirstPage` guard
+- `app/utils/newPosts.ts` - New post detection and fade: exports `PostTimestamps` type, `migratePostIds`, `markNewPosts` (with cooldown-aware opacity), `updateFadeOpacities`, `clearNewPostMarkers`, `isFirstPage`
 
 ### Keyboard Shortcuts
 
@@ -73,8 +73,9 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
 
 - `app/hooks/useSettings.ts` - Central hook managing all synced state via `@plasmohq/storage` (chrome.storage.sync):
   - Sort preference (`activeSort` / `setActiveSort`) — syncs across devices, reactive via watchers
-  - Post ID snapshots — stores/compares post IDs for new-post detection, first-page only
+  - Post timestamps — stores `Record<string, number>` (post ID → discovery timestamp, `-1` for known) per page; migrates old `string[]` format automatically
   - Show-new toggle — applies/removes `hns-show-new` CSS class on table body
+  - Fade interval — drives `--hns-fade` CSS custom property on new-post rows, with cooldown/showNew-aware lifecycle and memory leak guards (`mountedRef`, `intervalRef`, `showNewRef`)
 - All settings sync across devices via `chrome.storage.sync`
 - New-post detection only runs on first pages (skips paginated pages with `?p=...` or `?next=...`)
 
@@ -93,8 +94,9 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
   - `CSS_CLASSES` - Extension CSS class names (highlight, buttons, labels, `SHOW_NEW`, `NEW_POST`)
   - `CSS_SELECTORS` - Derived CSS selectors from class names
   - `SORT_OPTIONS` - Sort option configuration array (sort variant, display text, keyboard shortcut)
-  - `SETTINGS_KEYS` - Storage key names for chrome.storage.sync (`SHOW_NEW`, `LAST_ACTIVE_SORT`, `POST_IDS_PREFIX`)
+  - `SETTINGS_KEYS` - Storage key names for chrome.storage.sync (`SHOW_NEW`, `LAST_ACTIVE_SORT`, `POST_IDS_PREFIX`, `COOLDOWN`)
   - `SETTINGS_DEFAULTS` - Default values for settings
+  - `COOLDOWN_BOUNDS` - Min/max bounds for cooldown input validation
   - `HN_SELECTORS` - DOM selectors for HN page structure
   - `HN_CLASSES` - HN CSS class names for building test fixtures
 
@@ -102,6 +104,7 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
 
 - `SortVariant`: 'default' | 'points' | 'time' | 'comments'
 - `ParsedRow`: Contains DOM elements (title, info, spacer) and parsed numeric values for a single post
+- `PostTimestamps`: `Record<string, number>` — post ID → discovery timestamp (`Date.now()`), or `-1` for known/never-new posts (exported from `app/utils/newPosts.ts`)
 - `Settings`: Shape for extension settings (`hns-show-new` boolean, `hns-last-active-sort` SortVariant)
 
 ## Path Aliases

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -12,6 +12,7 @@ export const SETTINGS_KEYS = {
   REVIEW_DISMISSED: 'hns-review-dismissed',
   INSTALL_TIMESTAMP: 'hns-install-ts',
   SORT_COUNT: 'hns-sort-count',
+  COOLDOWN: 'hns-cooldown',
 } as const;
 
 export const SETTINGS_DEFAULTS = {
@@ -21,6 +22,12 @@ export const SETTINGS_DEFAULTS = {
   [SETTINGS_KEYS.REVIEW_DISMISSED]: false as boolean,
   [SETTINGS_KEYS.INSTALL_TIMESTAMP]: 0 as number,
   [SETTINGS_KEYS.SORT_COUNT]: 0 as number,
+  [SETTINGS_KEYS.COOLDOWN]: 3600 as number,
+} as const;
+
+export const COOLDOWN_BOUNDS = {
+  MIN: 10,
+  MAX: 86_400,
 } as const;
 
 // Chrome Web Store

--- a/app/hooks/useSettings.test.ts
+++ b/app/hooks/useSettings.test.ts
@@ -1,0 +1,369 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CSS_CLASSES, SETTINGS_DEFAULTS, SETTINGS_KEYS } from '~app/constants';
+import type { PostTimestamps } from '~app/utils/newPosts';
+
+const COOLDOWN = SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN];
+const COOLDOWN_MS = COOLDOWN * 1000;
+
+// --- Storage mock ---
+const storageStore: Record<string, unknown> = {};
+const watcherCallbacks: Record<string, (change: { newValue: unknown }) => void> = {};
+const mockSet = vi.fn((key: string, value: unknown) => {
+  storageStore[key] = value;
+  return Promise.resolve();
+});
+const mockGet = vi.fn((key: string) => Promise.resolve(storageStore[key]));
+const mockWatch = vi.fn((map: Record<string, (change: { newValue: unknown }) => void>) => {
+  Object.assign(watcherCallbacks, map);
+});
+const mockUnwatch = vi.fn();
+
+vi.mock('@plasmohq/storage', () => ({
+  Storage: class {
+    get = mockGet;
+    set = mockSet;
+    watch = mockWatch;
+    unwatch = mockUnwatch;
+  },
+}));
+
+// --- DOM helpers ---
+const setupTableBody = (ids: string[]) => {
+  const outerTable = document.createElement('table');
+  outerTable.id = 'hnmain';
+  const bigboxRow = document.createElement('tr');
+  bigboxRow.id = 'bigbox';
+  const bigboxTd = document.createElement('td');
+  const innerTable = document.createElement('table');
+  const tbody = document.createElement('tbody');
+
+  for (const id of ids) {
+    const tr = document.createElement('tr');
+    tr.classList.add('athing');
+    tr.id = id;
+    tbody.appendChild(tr);
+    tbody.appendChild(document.createElement('tr'));
+    const spacer = document.createElement('tr');
+    spacer.classList.add('spacer');
+    tbody.appendChild(spacer);
+  }
+
+  innerTable.appendChild(tbody);
+  bigboxTd.appendChild(innerTable);
+  bigboxRow.appendChild(bigboxTd);
+  outerTable.appendChild(bigboxRow);
+  document.body.appendChild(outerTable);
+  return tbody;
+};
+
+const clearBody = () => {
+  while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+};
+
+const getRowById = (id: string) => document.querySelector(`[id="${id}"]`) as HTMLElement;
+
+// --- Stubs ---
+vi.stubGlobal('location', { pathname: '/', search: '' });
+
+const { useSettings } = await import('./useSettings');
+
+describe('useSettings', () => {
+  beforeEach(() => {
+    clearBody();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000_000_000);
+    for (const key of Object.keys(storageStore)) delete storageStore[key];
+    for (const key of Object.keys(watcherCallbacks)) delete watcherCallbacks[key];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('init', () => {
+    it('should migrate string[] format to PostTimestamps', async () => {
+      setupTableBody(['post-1', 'post-2']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      storageStore['hns-post-ids:/'] = ['post-1', 'post-2'];
+
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      // Should save migrated format (with Date.now() timestamps since they're treated as fresh)
+      const savedData = mockSet.mock.calls.find((c) => c[0] === 'hns-post-ids:/')?.[1] as PostTimestamps;
+      expect(savedData).toBeDefined();
+      expect(typeof savedData['post-1']).toBe('number');
+      expect(Array.isArray(savedData)).toBe(false);
+    });
+
+    it('should not re-migrate PostTimestamps format', async () => {
+      setupTableBody(['post-1']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      const existing: PostTimestamps = { 'post-1': -1 };
+      storageStore['hns-post-ids:/'] = existing;
+
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      const savedData = mockSet.mock.calls.find((c) => c[0] === 'hns-post-ids:/')?.[1] as PostTimestamps;
+      expect(savedData).toBeDefined();
+      expect(savedData['post-1']).toBe(-1);
+    });
+
+    it('should mark new posts and start fade interval', async () => {
+      setupTableBody(['post-1', 'post-2']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      storageStore['hns-post-ids:/'] = { 'post-1': -1 } as PostTimestamps;
+
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      expect(getRowById('post-2').classList.contains(CSS_CLASSES.NEW_POST)).toBe(true);
+      expect(getRowById('post-2').style.getPropertyValue('--hns-fade')).toBe('1');
+    });
+
+    it('should use default cooldown when none is stored', async () => {
+      setupTableBody(['post-1', 'post-2']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      storageStore['hns-post-ids:/'] = { 'post-1': -1 } as PostTimestamps;
+
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      // The interval period should be based on default cooldown (600s → 12000ms)
+      const savedData = mockSet.mock.calls.find((c) => c[0] === 'hns-post-ids:/')?.[1] as PostTimestamps;
+      expect(savedData['post-2']).toBe(1_000_000_000_000);
+    });
+  });
+
+  describe('fade interval', () => {
+    it('should update opacity on interval tick', async () => {
+      setupTableBody(['post-1']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      storageStore['hns-post-ids:/'] = { 'old-1': -1 } as PostTimestamps;
+
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      // post-1 is new, starts at opacity 1
+      expect(getRowById('post-1').style.getPropertyValue('--hns-fade')).toBe('1');
+
+      // Advance halfway through cooldown
+      vi.advanceTimersByTime(COOLDOWN_MS / 2);
+
+      const opacity = Number(getRowById('post-1').style.getPropertyValue('--hns-fade'));
+      expect(opacity).toBeCloseTo(0.5, 1);
+    });
+
+    it('should remove class when cooldown expires but preserve timestamp', async () => {
+      setupTableBody(['post-1']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      storageStore['hns-post-ids:/'] = { 'old-1': -1 } as PostTimestamps;
+
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      // Advance past cooldown
+      vi.advanceTimersByTime(COOLDOWN_MS + 1000);
+
+      expect(getRowById('post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(false);
+      expect(getRowById('post-1').style.getPropertyValue('--hns-fade')).toBe('');
+    });
+
+    it('should clear interval on unmount', async () => {
+      setupTableBody(['post-1']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      storageStore['hns-post-ids:/'] = { 'old-1': -1 } as PostTimestamps;
+
+      const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+      const { unmount } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      unmount();
+      expect(clearIntervalSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('cooldown watcher', () => {
+    it('should restart interval with new period on cooldown change', async () => {
+      setupTableBody(['post-1']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      storageStore['hns-post-ids:/'] = { 'old-1': -1 } as PostTimestamps;
+
+      const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      const callsBefore = clearIntervalSpy.mock.calls.length;
+
+      // Simulate cooldown change from popup
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.COOLDOWN]?.({ newValue: 300 });
+      });
+
+      // Should have cleared the old interval
+      expect(clearIntervalSpy.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+
+    it('should revive indicators when cooldown is increased', async () => {
+      setupTableBody(['post-1']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      storageStore['hns-post-ids:/'] = { 'old-1': -1 } as PostTimestamps;
+
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      // post-1 is new, starts at opacity 1
+      expect(getRowById('post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(true);
+
+      // Advance past default cooldown
+      vi.advanceTimersByTime(COOLDOWN_MS + 1000);
+      expect(getRowById('post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(false);
+
+      // Double the cooldown — post-1 should reappear
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.COOLDOWN]?.({ newValue: COOLDOWN * 2 });
+      });
+
+      expect(getRowById('post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(true);
+    });
+
+    it('should not restart interval when showNew is off', async () => {
+      setupTableBody(['post-1']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = false;
+      storageStore['hns-post-ids:/'] = { 'old-1': -1 } as PostTimestamps;
+
+      const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      const callsBefore = setIntervalSpy.mock.calls.length;
+
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.COOLDOWN]?.({ newValue: 300 });
+      });
+
+      // setInterval should not have been called again
+      expect(setIntervalSpy.mock.calls.length).toBe(callsBefore);
+    });
+  });
+
+  describe('showNew watcher', () => {
+    it('should stop interval when toggled off', async () => {
+      setupTableBody(['post-1']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      storageStore['hns-post-ids:/'] = { 'old-1': -1 } as PostTimestamps;
+
+      const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.SHOW_NEW]?.({ newValue: false });
+      });
+
+      expect(clearIntervalSpy).toHaveBeenCalled();
+    });
+
+    it('should restart interval when toggled back on', async () => {
+      setupTableBody(['post-1']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      storageStore['hns-post-ids:/'] = { 'old-1': -1 } as PostTimestamps;
+
+      const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      // Toggle off then on
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.SHOW_NEW]?.({ newValue: false });
+      });
+      const callsAfterOff = setIntervalSpy.mock.calls.length;
+
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.SHOW_NEW]?.({ newValue: true });
+      });
+
+      expect(setIntervalSpy.mock.calls.length).toBeGreaterThan(callsAfterOff);
+    });
+  });
+
+  describe('postIds watcher', () => {
+    it('should re-apply marks from incoming timestamps without writing back', async () => {
+      setupTableBody(['post-1', 'post-2']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      storageStore['hns-post-ids:/'] = { 'post-1': -1, 'post-2': -1 } as PostTimestamps;
+
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      mockSet.mockClear();
+
+      // Simulate incoming timestamps from another tab
+      const incomingTs: PostTimestamps = { 'post-1': Date.now(), 'post-2': -1 };
+      act(() => {
+        watcherCallbacks['hns-post-ids:/']?.({ newValue: incomingTs });
+      });
+
+      // post-1 should be marked as new
+      expect(getRowById('post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(true);
+      // Should NOT have written back to storage
+      expect(mockSet).not.toHaveBeenCalledWith('hns-post-ids:/', expect.anything());
+    });
+
+    it('should handle migrated array format from watcher', async () => {
+      setupTableBody(['post-1']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      storageStore['hns-post-ids:/'] = { 'post-1': -1 } as PostTimestamps;
+
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      // Simulate old-format data from another tab that hasn't updated yet
+      act(() => {
+        watcherCallbacks['hns-post-ids:/']?.({ newValue: ['post-1'] });
+      });
+
+      // Should not throw, should handle gracefully
+      expect(getRowById('post-1')).toBeDefined();
+    });
+  });
+
+  describe('memory leak prevention', () => {
+    it('should call unwatch on unmount', async () => {
+      setupTableBody([]);
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      const { unmount } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      unmount();
+      expect(mockUnwatch).toHaveBeenCalled();
+    });
+
+    it('should not start interval after unmount during async init', async () => {
+      setupTableBody(['post-1']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      storageStore['hns-post-ids:/'] = { 'old-1': -1 } as PostTimestamps;
+
+      const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+      const { unmount } = renderHook(() => useSettings());
+
+      // Unmount before init completes
+      unmount();
+      await act(() => Promise.resolve());
+
+      // setInterval should not have been called after unmount
+      // (the mountedRef guard should prevent it)
+      const intervalCallsAfterUnmount = setIntervalSpy.mock.calls.length;
+      // Advance time to check no intervals fire
+      vi.advanceTimersByTime(COOLDOWN_MS);
+      expect(setIntervalSpy.mock.calls.length).toBe(intervalCallsAfterUnmount);
+    });
+  });
+});

--- a/app/hooks/useSettings.test.ts
+++ b/app/hooks/useSettings.test.ts
@@ -140,6 +140,35 @@ describe('useSettings', () => {
     });
   });
 
+  describe('setActiveSort', () => {
+    it('should update state and persist to storage', async () => {
+      setupTableBody([]);
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      const { result } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      act(() => result.current.setActiveSort('time'));
+      expect(result.current.activeSort).toBe('time');
+      expect(mockSet).toHaveBeenCalledWith(SETTINGS_KEYS.LAST_ACTIVE_SORT, 'time');
+    });
+  });
+
+  describe('LAST_ACTIVE_SORT watcher', () => {
+    it('should update activeSort from watcher after init', async () => {
+      setupTableBody([]);
+      const { result } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.LAST_ACTIVE_SORT]?.({ newValue: 'comments' });
+      });
+
+      expect(result.current.activeSort).toBe('comments');
+    });
+  });
+
   describe('fade interval', () => {
     it('should update opacity on interval tick', async () => {
       setupTableBody(['post-1']);
@@ -230,6 +259,26 @@ describe('useSettings', () => {
       });
 
       expect(getRowById('post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(true);
+    });
+
+    it('should stop interval when no posts were ever new', async () => {
+      setupTableBody(['post-1']);
+      storageStore[SETTINGS_KEYS.SHOW_NEW] = true;
+      // All posts are known (-1), none were ever new
+      storageStore['hns-post-ids:/'] = { 'post-1': -1 } as PostTimestamps;
+
+      const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+      renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      const callsBefore = setIntervalSpy.mock.calls.length;
+
+      // Change cooldown — should NOT start interval since no active timestamps
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.COOLDOWN]?.({ newValue: 120 });
+      });
+
+      expect(setIntervalSpy.mock.calls.length).toBe(callsBefore);
     });
 
     it('should not restart interval when showNew is off', async () => {

--- a/app/hooks/useSettings.ts
+++ b/app/hooks/useSettings.ts
@@ -4,7 +4,15 @@ import { Storage, type StorageCallbackMap } from '@plasmohq/storage';
 
 import { CSS_CLASSES, SETTINGS_DEFAULTS, SETTINGS_KEYS } from '~app/constants';
 import type { SortVariant } from '~app/types';
-import { clearNewPostMarkers, getPostIds, isFirstPage, markNewPosts } from '~app/utils/newPosts';
+import type { PostTimestamps } from '~app/utils/newPosts';
+import {
+  clearNewPostMarkers,
+  getPostIds,
+  isFirstPage,
+  markNewPosts,
+  migratePostIds,
+  updateFadeOpacities,
+} from '~app/utils/newPosts';
 import { getTableBody } from '~app/utils/selectors';
 
 const storage = new Storage();
@@ -19,6 +27,11 @@ type UseSettingsReturn = {
 export const useSettings = (): UseSettingsReturn => {
   const [activeSort, setActiveSortState] = useState<SortVariant>(SETTINGS_DEFAULTS[SETTINGS_KEYS.LAST_ACTIVE_SORT]);
   const initializedRef = useRef(false);
+  const timestampsRef = useRef<PostTimestamps>({});
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const cooldownRef = useRef<number>(SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN]);
+  const showNewRef = useRef(true);
+  const mountedRef = useRef(true);
 
   const setActiveSort = useCallback((sort: SortVariant) => {
     setActiveSortState(sort);
@@ -26,7 +39,27 @@ export const useSettings = (): UseSettingsReturn => {
   }, []);
 
   useEffect(() => {
+    mountedRef.current = true;
     const tableBody = getTableBody();
+    const postIdsKey = getPostIdsKey();
+
+    const stopFadeInterval = () => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+
+    const startFadeInterval = () => {
+      stopFadeInterval();
+      const cooldownMs = cooldownRef.current * 1000;
+      const period = Math.max(1000, Math.floor(cooldownMs / 50));
+      intervalRef.current = setInterval(() => {
+        updateFadeOpacities(timestampsRef.current, cooldownMs);
+      }, period);
+    };
+
+    const hasActiveTimestamps = (ts: PostTimestamps): boolean => Object.values(ts).some((v) => v > 0);
 
     // --- Show New ---
     const applyShowNew = (enabled: boolean) => {
@@ -38,32 +71,34 @@ export const useSettings = (): UseSettingsReturn => {
       }
     };
 
-    // --- Post IDs ---
-    const applyPostIds = (storedIds: string[]) => {
-      if (!tableBody || !isFirstPage()) return;
-      clearNewPostMarkers();
-      const currentIds = getPostIds();
-      const previousIds = new Set(storedIds);
-      markNewPosts(currentIds, previousIds);
-    };
-
     // --- Init ---
     const init = async () => {
       const showNew = await storage.get<boolean>(SETTINGS_KEYS.SHOW_NEW);
-      applyShowNew(showNew ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.SHOW_NEW]);
+      const showNewValue = showNew ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.SHOW_NEW];
+      showNewRef.current = showNewValue;
+      applyShowNew(showNewValue);
 
       const sort = await storage.get<SortVariant>(SETTINGS_KEYS.LAST_ACTIVE_SORT);
       setActiveSortState(sort ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.LAST_ACTIVE_SORT]);
 
+      const cooldown = await storage.get<number>(SETTINGS_KEYS.COOLDOWN);
+      cooldownRef.current = cooldown ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN];
+
       if (isFirstPage()) {
-        const postIdsKey = getPostIdsKey();
-        const storedIds = await storage.get<string[]>(postIdsKey);
+        const stored = await storage.get<string[] | PostTimestamps>(postIdsKey);
         const currentIds = getPostIds();
 
         if (currentIds.length > 0) {
-          const previousIds = new Set(storedIds ?? []);
-          markNewPosts(currentIds, previousIds);
-          await storage.set(postIdsKey, currentIds);
+          const previousTimestamps = stored ? migratePostIds(stored) : {};
+          const cooldownMs = cooldownRef.current * 1000;
+          const newTimestamps = markNewPosts(currentIds, previousTimestamps, cooldownMs);
+          timestampsRef.current = newTimestamps;
+          await storage.set(postIdsKey, newTimestamps);
+
+          if (!mountedRef.current) return;
+          if (showNewRef.current && hasActiveTimestamps(newTimestamps)) {
+            startFadeInterval();
+          }
         }
       }
 
@@ -75,21 +110,66 @@ export const useSettings = (): UseSettingsReturn => {
     // --- Watchers ---
     const watcherMap: StorageCallbackMap = {
       [SETTINGS_KEYS.SHOW_NEW]: (change) => {
-        applyShowNew(change.newValue ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.SHOW_NEW]);
+        const enabled = (change.newValue as boolean | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.SHOW_NEW];
+        showNewRef.current = enabled;
+        applyShowNew(enabled);
+        if (enabled) {
+          // Re-apply marks and restart interval
+          if (isFirstPage()) {
+            clearNewPostMarkers();
+            const currentIds = getPostIds();
+            const cooldownMs = cooldownRef.current * 1000;
+            const newTs = markNewPosts(currentIds, timestampsRef.current, cooldownMs);
+            timestampsRef.current = newTs;
+            if (hasActiveTimestamps(newTs)) {
+              startFadeInterval();
+            }
+          }
+        } else {
+          stopFadeInterval();
+          clearNewPostMarkers();
+        }
       },
       [SETTINGS_KEYS.LAST_ACTIVE_SORT]: (change) => {
         if (!initializedRef.current) return;
-        setActiveSortState(change.newValue ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.LAST_ACTIVE_SORT]);
+        setActiveSortState(
+          (change.newValue as SortVariant | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.LAST_ACTIVE_SORT],
+        );
       },
-      [getPostIdsKey()]: (change) => {
+      [SETTINGS_KEYS.COOLDOWN]: (change) => {
+        cooldownRef.current = (change.newValue as number | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN];
+        if (showNewRef.current && isFirstPage()) {
+          // Re-apply marks so indicators can reappear if cooldown was increased
+          clearNewPostMarkers();
+          const currentIds = getPostIds();
+          const cooldownMs = cooldownRef.current * 1000;
+          const newTs = markNewPosts(currentIds, timestampsRef.current, cooldownMs);
+          timestampsRef.current = newTs;
+          if (hasActiveTimestamps(newTs)) {
+            startFadeInterval();
+          } else {
+            stopFadeInterval();
+          }
+        }
+      },
+      [postIdsKey]: (change) => {
         if (!initializedRef.current) return;
-        applyPostIds(change.newValue ?? []);
+        const incoming = (change.newValue ?? {}) as string[] | PostTimestamps;
+        const migrated = Array.isArray(incoming) ? migratePostIds(incoming) : (incoming as PostTimestamps);
+        clearNewPostMarkers();
+        const currentIds = getPostIds();
+        const cooldownMs = cooldownRef.current * 1000;
+        const newTs = markNewPosts(currentIds, migrated, cooldownMs);
+        timestampsRef.current = newTs;
+        // Do NOT write back to storage (prevents ping-pong)
       },
     };
 
     storage.watch(watcherMap);
 
     return () => {
+      mountedRef.current = false;
+      stopFadeInterval();
       storage.unwatch(watcherMap);
     };
   }, []);

--- a/app/popup.test.tsx
+++ b/app/popup.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { SETTINGS_KEYS } from '~app/constants';
+import { COOLDOWN_BOUNDS, SETTINGS_KEYS } from '~app/constants';
 
 let storageValues: Record<string, unknown> = {};
 
@@ -53,5 +53,31 @@ describe('Popup', () => {
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', expect.stringContaining('chromewebstore.google.com'));
     expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('should show cooldown input when showNew is true', () => {
+    storageValues = { [SETTINGS_KEYS.SHOW_NEW]: true };
+    render(<Popup />);
+
+    const input = screen.getByLabelText('Fade duration in seconds');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('type', 'number');
+    expect(input).toHaveAttribute('min', String(COOLDOWN_BOUNDS.MIN));
+    expect(input).toHaveAttribute('max', String(COOLDOWN_BOUNDS.MAX));
+  });
+
+  it('should hide cooldown input when showNew is false', () => {
+    storageValues = { [SETTINGS_KEYS.SHOW_NEW]: false };
+    render(<Popup />);
+
+    expect(screen.queryByLabelText('Fade duration in seconds')).not.toBeInTheDocument();
+  });
+
+  it('should display default cooldown value', () => {
+    storageValues = { [SETTINGS_KEYS.SHOW_NEW]: true, [SETTINGS_KEYS.COOLDOWN]: 300 };
+    render(<Popup />);
+
+    const input = screen.getByLabelText('Fade duration in seconds') as HTMLInputElement;
+    expect(input.value).toBe('300');
   });
 });

--- a/app/utils/newPosts.test.ts
+++ b/app/utils/newPosts.test.ts
@@ -2,7 +2,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CSS_CLASSES, HN_SELECTORS } from '~app/constants';
 
-import { clearNewPostMarkers, getPostIds, isFirstPage, markNewPosts } from './newPosts';
+import type { PostTimestamps } from './newPosts';
+import {
+  clearNewPostMarkers,
+  getPostIds,
+  isFirstPage,
+  markNewPosts,
+  migratePostIds,
+  updateFadeOpacities,
+} from './newPosts';
+
+const COOLDOWN = 600; // 10 minutes (seconds)
+const COOLDOWN_MS = COOLDOWN * 1000;
 
 const setupTableBody = (ids: string[]) => {
   const outerTable = document.createElement('table');
@@ -47,9 +58,12 @@ describe('newPosts', () => {
   beforeEach(() => {
     clearBody();
     vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000_000_000);
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -122,78 +136,205 @@ describe('newPosts', () => {
     });
   });
 
-  describe('markNewPosts', () => {
-    it('should add NEW_POST class to rows not in previousIds', () => {
-      setupTableBody(['post-1', 'post-2', 'post-3']);
-      const previousIds = new Set(['post-1']);
+  describe('migratePostIds', () => {
+    it('should convert string array to PostTimestamps with Date.now()', () => {
+      const result = migratePostIds(['post-1', 'post-2', 'post-3']);
+      expect(result).toEqual({
+        'post-1': 1_000_000_000_000,
+        'post-2': 1_000_000_000_000,
+        'post-3': 1_000_000_000_000,
+      });
+    });
 
-      markNewPosts(['post-1', 'post-2', 'post-3'], previousIds);
+    it('should return empty object for empty array', () => {
+      expect(migratePostIds([])).toEqual({});
+    });
+
+    it('should pass through PostTimestamps unchanged', () => {
+      const timestamps: PostTimestamps = { 'post-1': -1, 'post-2': 999 };
+      expect(migratePostIds(timestamps)).toBe(timestamps);
+    });
+  });
+
+  describe('markNewPosts', () => {
+    it('should add NEW_POST class and set --hns-fade to newly discovered posts', () => {
+      setupTableBody(['post-1', 'post-2', 'post-3']);
+      const previous: PostTimestamps = { 'post-1': -1 };
+
+      const result = markNewPosts(['post-1', 'post-2', 'post-3'], previous, COOLDOWN_MS);
 
       const tbody = document.querySelector(HN_SELECTORS.TABLE_BODY)!;
       expect(getRowById(tbody, 'post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(false);
       expect(getRowById(tbody, 'post-2').classList.contains(CSS_CLASSES.NEW_POST)).toBe(true);
       expect(getRowById(tbody, 'post-3').classList.contains(CSS_CLASSES.NEW_POST)).toBe(true);
+      expect(getRowById(tbody, 'post-2').style.getPropertyValue('--hns-fade')).toBe('1');
+      expect(getRowById(tbody, 'post-3').style.getPropertyValue('--hns-fade')).toBe('1');
+      expect(result['post-1']).toBe(-1);
+      expect(result['post-2']).toBe(1_000_000_000_000);
+      expect(result['post-3']).toBe(1_000_000_000_000);
     });
 
-    it('should not mark any posts when all are in previousIds', () => {
+    it('should not mark any posts when all are known', () => {
       setupTableBody(['post-1', 'post-2']);
-      const previousIds = new Set(['post-1', 'post-2']);
+      const previous: PostTimestamps = { 'post-1': -1, 'post-2': -1 };
 
-      markNewPosts(['post-1', 'post-2'], previousIds);
+      const result = markNewPosts(['post-1', 'post-2'], previous, COOLDOWN_MS);
 
       const tbody = document.querySelector(HN_SELECTORS.TABLE_BODY)!;
       expect(getRowById(tbody, 'post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(false);
       expect(getRowById(tbody, 'post-2').classList.contains(CSS_CLASSES.NEW_POST)).toBe(false);
+      expect(result['post-1']).toBe(-1);
+      expect(result['post-2']).toBe(-1);
     });
 
-    it('should skip marking when previousIds is empty', () => {
+    it('should return all IDs as -1 when previousTimestamps is empty (first visit)', () => {
       setupTableBody(['post-1', 'post-2']);
-      const previousIds = new Set<string>();
 
-      markNewPosts(['post-1', 'post-2'], previousIds);
+      const result = markNewPosts(['post-1', 'post-2'], {}, COOLDOWN_MS);
 
       const tbody = document.querySelector(HN_SELECTORS.TABLE_BODY)!;
       expect(getRowById(tbody, 'post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(false);
       expect(getRowById(tbody, 'post-2').classList.contains(CSS_CLASSES.NEW_POST)).toBe(false);
+      expect(result).toEqual({ 'post-1': -1, 'post-2': -1 });
     });
 
     it('should handle missing table body gracefully', () => {
-      const previousIds = new Set(['post-1']);
-      expect(() => markNewPosts(['post-2'], previousIds)).not.toThrow();
+      const previous: PostTimestamps = { 'post-1': -1 };
+      expect(() => markNewPosts(['post-2'], previous, COOLDOWN_MS)).not.toThrow();
     });
 
     it('should handle IDs in currentIds that do not exist in DOM', () => {
       setupTableBody(['post-1']);
-      const previousIds = new Set(['post-1']);
+      const previous: PostTimestamps = { 'post-1': -1 };
 
-      expect(() => markNewPosts(['post-1', 'post-99'], previousIds)).not.toThrow();
+      expect(() => markNewPosts(['post-1', 'post-99'], previous, COOLDOWN_MS)).not.toThrow();
     });
 
     it('should mark all posts as new when none were previously seen', () => {
       setupTableBody(['post-1', 'post-2', 'post-3']);
-      const previousIds = new Set(['old-1', 'old-2']);
+      const previous: PostTimestamps = { 'old-1': -1, 'old-2': -1 };
 
-      markNewPosts(['post-1', 'post-2', 'post-3'], previousIds);
+      markNewPosts(['post-1', 'post-2', 'post-3'], previous, COOLDOWN_MS);
 
       const tbody = document.querySelector(HN_SELECTORS.TABLE_BODY)!;
       expect(getRowById(tbody, 'post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(true);
       expect(getRowById(tbody, 'post-2').classList.contains(CSS_CLASSES.NEW_POST)).toBe(true);
       expect(getRowById(tbody, 'post-3').classList.contains(CSS_CLASSES.NEW_POST)).toBe(true);
     });
+
+    it('should re-apply fading posts with correct intermediate opacity', () => {
+      setupTableBody(['post-1']);
+      const halfwayTs = Date.now() - COOLDOWN_MS / 2; // halfway through cooldown
+      const previous: PostTimestamps = { 'post-1': halfwayTs };
+
+      const result = markNewPosts(['post-1'], previous, COOLDOWN_MS);
+
+      const tbody = document.querySelector(HN_SELECTORS.TABLE_BODY)!;
+      expect(getRowById(tbody, 'post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(true);
+      expect(Number(getRowById(tbody, 'post-1').style.getPropertyValue('--hns-fade'))).toBeCloseTo(0.5);
+      expect(result['post-1']).toBe(halfwayTs);
+    });
+
+    it('should keep timestamp but not show indicator for expired posts', () => {
+      setupTableBody(['post-1']);
+      const expiredTs = Date.now() - COOLDOWN_MS - 1000; // past cooldown
+      const previous: PostTimestamps = { 'post-1': expiredTs };
+
+      const result = markNewPosts(['post-1'], previous, COOLDOWN_MS);
+
+      const tbody = document.querySelector(HN_SELECTORS.TABLE_BODY)!;
+      expect(getRowById(tbody, 'post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(false);
+      expect(result['post-1']).toBe(expiredTs); // timestamp preserved, not -1
+    });
+
+    it('should revive indicator when cooldown is increased past expiry', () => {
+      setupTableBody(['post-1']);
+      const ts = Date.now() - 120_000; // 2 minutes ago
+      const previous: PostTimestamps = { 'post-1': ts };
+
+      // With 1-minute cooldown: expired
+      const result1 = markNewPosts(['post-1'], previous, 60_000);
+      const tbody = document.querySelector(HN_SELECTORS.TABLE_BODY)!;
+      expect(getRowById(tbody, 'post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(false);
+      expect(result1['post-1']).toBe(ts);
+
+      // With 5-minute cooldown: alive again
+      const result2 = markNewPosts(['post-1'], result1, 300_000);
+      expect(getRowById(tbody, 'post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(true);
+      expect(result2['post-1']).toBe(ts);
+    });
+  });
+
+  describe('updateFadeOpacities', () => {
+    it('should set correct --hns-fade values on DOM elements', () => {
+      setupTableBody(['post-1', 'post-2']);
+      const tbody = document.querySelector(HN_SELECTORS.TABLE_BODY)!;
+      getRowById(tbody, 'post-1').classList.add(CSS_CLASSES.NEW_POST);
+      getRowById(tbody, 'post-2').classList.add(CSS_CLASSES.NEW_POST);
+
+      const timestamps: PostTimestamps = {
+        'post-1': Date.now() - COOLDOWN_MS / 4, // 75% remaining
+        'post-2': Date.now() - COOLDOWN_MS / 2, // 50% remaining
+      };
+
+      updateFadeOpacities(timestamps, COOLDOWN_MS);
+
+      expect(Number(getRowById(tbody, 'post-1').style.getPropertyValue('--hns-fade'))).toBeCloseTo(0.75);
+      expect(Number(getRowById(tbody, 'post-2').style.getPropertyValue('--hns-fade'))).toBeCloseTo(0.5);
+    });
+
+    it('should remove class when opacity reaches 0 but preserve timestamp', () => {
+      setupTableBody(['post-1']);
+      const tbody = document.querySelector(HN_SELECTORS.TABLE_BODY)!;
+      getRowById(tbody, 'post-1').classList.add(CSS_CLASSES.NEW_POST);
+
+      const timestamps: PostTimestamps = {
+        'post-1': Date.now() - COOLDOWN_MS - 1000, // past cooldown
+      };
+
+      updateFadeOpacities(timestamps, COOLDOWN_MS);
+
+      expect(getRowById(tbody, 'post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(false);
+      expect(getRowById(tbody, 'post-1').style.getPropertyValue('--hns-fade')).toBe('');
+      // Timestamp is NOT modified by updateFadeOpacities
+      expect(timestamps['post-1']).toBe(Date.now() - COOLDOWN_MS - 1000);
+    });
+
+    it('should skip IDs with timestamp -1', () => {
+      setupTableBody(['post-1']);
+
+      const timestamps: PostTimestamps = { 'post-1': -1 };
+      updateFadeOpacities(timestamps, COOLDOWN_MS);
+
+      // No class was added/removed, no error thrown
+      const tbody = document.querySelector(HN_SELECTORS.TABLE_BODY)!;
+      expect(getRowById(tbody, 'post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(false);
+    });
+
+    it('should handle missing DOM elements gracefully', () => {
+      setupTableBody([]);
+      const timestamps: PostTimestamps = { 'post-1': Date.now() };
+
+      expect(() => updateFadeOpacities(timestamps, COOLDOWN_MS)).not.toThrow();
+    });
   });
 
   describe('clearNewPostMarkers', () => {
-    it('should remove NEW_POST class from all marked rows', () => {
+    it('should remove NEW_POST class and --hns-fade from all marked rows', () => {
       setupTableBody(['post-1', 'post-2', 'post-3']);
       const tbody = document.querySelector(HN_SELECTORS.TABLE_BODY)!;
       getRowById(tbody, 'post-1').classList.add(CSS_CLASSES.NEW_POST);
+      getRowById(tbody, 'post-1').style.setProperty('--hns-fade', '0.5');
       getRowById(tbody, 'post-3').classList.add(CSS_CLASSES.NEW_POST);
+      getRowById(tbody, 'post-3').style.setProperty('--hns-fade', '0.8');
 
       clearNewPostMarkers();
 
       expect(getRowById(tbody, 'post-1').classList.contains(CSS_CLASSES.NEW_POST)).toBe(false);
+      expect(getRowById(tbody, 'post-1').style.getPropertyValue('--hns-fade')).toBe('');
       expect(getRowById(tbody, 'post-2').classList.contains(CSS_CLASSES.NEW_POST)).toBe(false);
       expect(getRowById(tbody, 'post-3').classList.contains(CSS_CLASSES.NEW_POST)).toBe(false);
+      expect(getRowById(tbody, 'post-3').style.getPropertyValue('--hns-fade')).toBe('');
     });
 
     it('should handle no marked rows gracefully', () => {

--- a/app/utils/newPosts.ts
+++ b/app/utils/newPosts.ts
@@ -1,6 +1,10 @@
 import { CSS_CLASSES } from '~app/constants';
 import { getTableBody } from '~app/utils/selectors';
 
+export type PostTimestamps = Record<string, number>;
+
+const FADE_PROPERTY = '--hns-fade';
+
 export const isFirstPage = (): boolean => {
   const params = new URLSearchParams(window.location.search);
   return !(params.has('p') || params.has('next'));
@@ -14,16 +18,76 @@ export const getPostIds = (): string[] => {
   return Array.from(rows, (row) => row.id);
 };
 
-export const markNewPosts = (currentIds: string[], previousIds: Set<string>): void => {
-  if (previousIds.size === 0) return;
+export const migratePostIds = (stored: string[] | PostTimestamps): PostTimestamps => {
+  if (Array.isArray(stored)) {
+    return Object.fromEntries(stored.map((id) => [id, Date.now()]));
+  }
+  return stored;
+};
+
+export const markNewPosts = (
+  currentIds: string[],
+  previousTimestamps: PostTimestamps,
+  cooldownMs: number,
+): PostTimestamps => {
+  const result: PostTimestamps = {};
+
+  if (Object.keys(previousTimestamps).length === 0) {
+    for (const id of currentIds) result[id] = -1;
+    return result;
+  }
 
   const tableBody = getTableBody();
-  if (!tableBody) return;
 
   for (const id of currentIds) {
-    if (!previousIds.has(id)) {
-      const row = tableBody.querySelector<HTMLElement>(`tr.athing[id="${id}"]`);
-      if (row) row.classList.add(CSS_CLASSES.NEW_POST);
+    const ts = previousTimestamps[id];
+
+    if (ts === undefined) {
+      // New post
+      result[id] = Date.now();
+      if (tableBody) {
+        const row = tableBody.querySelector<HTMLElement>(`tr.athing[id="${id}"]`);
+        if (row) {
+          row.classList.add(CSS_CLASSES.NEW_POST);
+          row.style.setProperty(FADE_PROPERTY, '1');
+        }
+      }
+    } else if (ts > 0) {
+      // Previously discovered, keep original timestamp
+      result[id] = ts;
+      const remaining = ts + cooldownMs - Date.now();
+      if (remaining > 0 && tableBody) {
+        const row = tableBody.querySelector<HTMLElement>(`tr.athing[id="${id}"]`);
+        if (row) {
+          row.classList.add(CSS_CLASSES.NEW_POST);
+          row.style.setProperty(FADE_PROPERTY, String(remaining / cooldownMs));
+        }
+      }
+    } else {
+      // Known (-1): never was new
+      result[id] = -1;
+    }
+  }
+
+  return result;
+};
+
+export const updateFadeOpacities = (timestamps: PostTimestamps, cooldownMs: number): void => {
+  const tableBody = getTableBody();
+
+  for (const [id, ts] of Object.entries(timestamps)) {
+    if (ts <= 0) continue;
+
+    if (!tableBody) continue;
+    const row = tableBody.querySelector<HTMLElement>(`tr.athing[id="${id}"]`);
+    if (!row) continue;
+
+    const opacity = Math.max(0, (ts + cooldownMs - Date.now()) / cooldownMs);
+    if (opacity <= 0) {
+      row.classList.remove(CSS_CLASSES.NEW_POST);
+      row.style.removeProperty(FADE_PROPERTY);
+    } else {
+      row.style.setProperty(FADE_PROPERTY, String(opacity));
     }
   }
 };
@@ -32,8 +96,9 @@ export const clearNewPostMarkers = (): void => {
   const tableBody = getTableBody();
   if (!tableBody) return;
 
-  const rows = tableBody.querySelectorAll(`.${CSS_CLASSES.NEW_POST}`);
+  const rows = tableBody.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.NEW_POST}`);
   for (const row of rows) {
     row.classList.remove(CSS_CLASSES.NEW_POST);
+    row.style.removeProperty(FADE_PROPERTY);
   }
 };

--- a/content.css
+++ b/content.css
@@ -73,6 +73,7 @@
   color: #ff6600;
   margin-right: 4px;
   font-weight: bold;
+  opacity: var(--hns-fade, 1);
 }
 
 /* Review toast (speech bubble below sort menu) */
@@ -154,5 +155,9 @@
 @media (prefers-reduced-motion: reduce) {
   .hns-review-link {
     transition: none;
+  }
+
+  .hns-show-new tr.hns-new-post .titleline::before {
+    opacity: 1;
   }
 }

--- a/popup.css
+++ b/popup.css
@@ -126,6 +126,24 @@ h1 {
   text-decoration: underline;
 }
 
+.hns-number-input {
+  width: 60px;
+  padding: 3px 4px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: 1;
+  text-align: right;
+  margin-left: 12px;
+}
+
+.hns-number-input:focus {
+  outline: 2px solid #ff6600;
+  outline-offset: 1px;
+  border-color: transparent;
+}
+
 /* Suppress toggle animation on load while useStorage settles (see popup.tsx) */
 .hns-no-transition .hns-toggle-slider,
 .hns-no-transition .hns-toggle-slider::before {

--- a/popup.tsx
+++ b/popup.tsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from 'react';
 
 import { useStorage } from '@plasmohq/storage/hook';
 
-import { CWS_REVIEW_URL, SETTINGS_DEFAULTS, SETTINGS_KEYS } from '~app/constants';
+import { COOLDOWN_BOUNDS, CWS_REVIEW_URL, SETTINGS_DEFAULTS, SETTINGS_KEYS } from '~app/constants';
 
 import './popup.css';
 
 const Popup = () => {
   const [showNew, setShowNew] = useStorage(SETTINGS_KEYS.SHOW_NEW, SETTINGS_DEFAULTS[SETTINGS_KEYS.SHOW_NEW]);
+  const [cooldown, setCooldown] = useStorage(SETTINGS_KEYS.COOLDOWN, SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN]);
   const [layoutOk] = useStorage(SETTINGS_KEYS.LAYOUT_OK, SETTINGS_DEFAULTS[SETTINGS_KEYS.LAYOUT_OK]);
   // useStorage renders with the default value first, then async-loads the stored value.
   // When stored !== default, the CSS transition animates the toggle visibly (on→off flash).
@@ -46,6 +47,30 @@ const Popup = () => {
           <span className="hns-toggle-slider" />
         </label>
       </div>
+
+      {showNew && (
+        <div className="hns-setting">
+          <span>Fade duration (sec)</span>
+          <input
+            type="number"
+            name="cooldown"
+            aria-label="Fade duration in seconds"
+            min={COOLDOWN_BOUNDS.MIN}
+            max={COOLDOWN_BOUNDS.MAX}
+            value={cooldown}
+            onChange={(e) => setCooldown(Number(e.target.value))}
+            onBlur={(e) =>
+              setCooldown(
+                Math.max(
+                  COOLDOWN_BOUNDS.MIN,
+                  Math.min(COOLDOWN_BOUNDS.MAX, Number(e.target.value) || SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN]),
+                ),
+              )
+            }
+            className="hns-number-input"
+          />
+        </div>
+      )}
 
       <div className="hns-review-link">
         Enjoying HN Sorted?{' '}


### PR DESCRIPTION
## Summary
- New post indicators persist across page reloads and fade from 100% to 0% opacity over a configurable cooldown (default 60 min, range 10s–24h)
- Storage format migrates from `string[]` to `Record<string, number>` (post ID → discovery timestamp) with automatic in-place detection
- Timestamps are never destroyed on expiry — adjusting cooldown up revives indicators that are still within the new window
- Popup gets a number input for cooldown (shown when highlight toggle is on), validated on blur to allow free typing
- Respects `prefers-reduced-motion` (no fade, instant show/hide)
- Memory leak prevention: `mountedRef` guard for async init, `intervalRef` cleanup on unmount, `showNewRef` guard against toggle/cooldown watcher races

## Test plan
- [x] `bun run test` — 156 tests pass (includes new `useSettings.test.ts` with 16 tests)
- [x] `bun run lint` — no errors
- [x] Load extension on HN, reload page — new posts show fading orange bullet
- [x] Change cooldown in popup — fade speed adjusts, increasing cooldown revives expired indicators
- [x] Toggle highlight off/on — indicators pause and resume at correct opacity
- [x] Open two HN tabs — cross-tab sync works without write loops
- [x] Install over old version — `string[]` storage migrates seamlessly