### PR TITLE
feat(time): use Unix timestamp for sorting and add true time ago display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rewrite Chrome Web Store description for better discoverability
-
-### Changed
-
 - Time sorting now uses Unix timestamp from title attribute instead of ISO date parsing
 
 ## [2.4.0] - 2026-03-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New post indicator cooldown with opacity fade — indicators persist across reloads and fade out over a configurable period (default 60 min, range 10s–24h)
 - Cooldown setting in extension popup (visible when "Highlight new posts" is on)
+- "Show true time ago" setting — corrects misleading age text on HN "second chance" posts (e.g., "7 hours ago" → "3 days ago"), enabled by default with toggle in popup
 - Review prompt: dismissible bar above post table after 7 days or 20 sorts
 - Persistent review link in extension popup
 - Demo video and GIF generation script (`bun run demo`)
 - Chrome storage polyfill for Playwright-based screenshot/demo scripts
+- HN format canary tests to detect title attribute or age text format changes
 
 ### Changed
 
 - Rewrite Chrome Web Store description for better discoverability
+
+### Changed
+
+- Time sorting now uses Unix timestamp from title attribute instead of ISO date parsing
 
 ## [2.4.0] - 2026-03-13
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
 
 - `popup.tsx` - Settings popup UI with toggle switch for new-post indicators and cooldown number input; shows a warning banner when layout detection fails
 - `popup.css` - Popup styles (toggle switches, layout, warning banner)
-- Uses `@plasmohq/storage` `useStorage` hook for reactive persistence to `chrome.storage.sync`
+- Uses `useSettingsStorage` helper — a typed wrapper around `useStorage` that auto-resolves defaults from `SETTINGS_DEFAULTS`
 
 ### Component Structure
 
@@ -58,9 +58,9 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
 ### Key Utils
 
 - `app/utils/selectors.ts` - DOM selectors for HN's table structure (title rows at 3n+1, info rows at 3n+2, spacer rows at 3n+3)
-- `app/utils/parsers.ts` - Extract numeric values (points, time, comments) from info rows
+- `app/utils/parsers.ts` - Extract numeric values (points, time, comments) from info rows; `getTime` parses the Unix timestamp (second part) from the `.age` title attribute (`"ISO_DATETIME UNIX_TIMESTAMP"`)
 - `app/utils/sorters.ts` - Sort functions for each sort variant
-- `app/utils/presenters.ts` - DOM manipulation to update table and highlight active sort column
+- `app/utils/presenters.ts` - DOM manipulation to update table, highlight active sort column, and correct age text (`formatAge`, `correctAgeTexts`, `restoreAgeTexts`)
 - `app/utils/newPosts.ts` - New post detection and fade: exports `PostTimestamps` type, `migratePostIds`, `markNewPosts` (with cooldown-aware opacity), `updateFadeOpacities`, `clearNewPostMarkers`, `isFirstPage`
 
 ### Keyboard Shortcuts
@@ -76,8 +76,15 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
   - Post timestamps — stores `Record<string, number>` (post ID → discovery timestamp, `-1` for known) per page; migrates old `string[]` format automatically
   - Show-new toggle — applies/removes `hns-show-new` CSS class on table body
   - Fade interval — drives `--hns-fade` CSS custom property on new-post rows, with cooldown/showNew-aware lifecycle and memory leak guards (`mountedRef`, `intervalRef`, `showNewRef`)
+  - True time ago toggle (`showTrueTimeAgo`) — exposes reactive boolean for age text correction
 - All settings sync across devices via `chrome.storage.sync`
 - New-post detection only runs on first pages (skips paginated pages with `?p=...` or `?next=...`)
+
+### True Time Ago
+
+- HN "second chance" posts show misleading age text (e.g., "7 hours ago" for a 3-day-old resubmission) because the server resets the display text while the title attribute retains the original submission timestamp
+- `formatAge` in `app/utils/presenters.ts` computes correct age from Unix timestamp; `correctAgeTexts`/`restoreAgeTexts` swap the `<a>` text inside `.age` spans, preserving originals via `data-original-age`
+- Toggle in popup (default: on), wired through `useSettings` → `ControlPanel` useEffect
 
 ### Review Prompt
 
@@ -94,7 +101,7 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
   - `CSS_CLASSES` - Extension CSS class names (highlight, buttons, labels, `SHOW_NEW`, `NEW_POST`)
   - `CSS_SELECTORS` - Derived CSS selectors from class names
   - `SORT_OPTIONS` - Sort option configuration array (sort variant, display text, keyboard shortcut)
-  - `SETTINGS_KEYS` - Storage key names for chrome.storage.sync (`SHOW_NEW`, `LAST_ACTIVE_SORT`, `POST_IDS_PREFIX`, `COOLDOWN`)
+  - `SETTINGS_KEYS` - Storage key names for chrome.storage.sync (`SHOW_NEW`, `LAST_ACTIVE_SORT`, `POST_IDS_PREFIX`, `COOLDOWN`, `TRUE_TIME_AGO`)
   - `SETTINGS_DEFAULTS` - Default values for settings
   - `COOLDOWN_BOUNDS` - Min/max bounds for cooldown input validation
   - `HN_SELECTORS` - DOM selectors for HN page structure

--- a/app/components/ControlPanel.test.tsx
+++ b/app/components/ControlPanel.test.tsx
@@ -21,7 +21,7 @@ vi.mock('~app/utils/presenters', () => ({
 vi.mock('~app/hooks/useSettings', () => ({
   useSettings: () => {
     const [activeSort, setActiveSort] = useState<SortVariant>('points');
-    return { activeSort, setActiveSort, showTrueTimeAgo: false };
+    return { activeSort, setActiveSort, showTrueTimeAgo: true };
   },
 }));
 

--- a/app/components/ControlPanel.test.tsx
+++ b/app/components/ControlPanel.test.tsx
@@ -14,12 +14,14 @@ vi.mock('~app/hooks/useParsedRows', () => ({
 
 vi.mock('~app/utils/presenters', () => ({
   updateTable: vi.fn(),
+  correctAgeTexts: vi.fn(),
+  restoreAgeTexts: vi.fn(),
 }));
 
 vi.mock('~app/hooks/useSettings', () => ({
   useSettings: () => {
     const [activeSort, setActiveSort] = useState<SortVariant>('points');
-    return { activeSort, setActiveSort };
+    return { activeSort, setActiveSort, showTrueTimeAgo: false };
   },
 }));
 

--- a/app/components/ControlPanel.test.tsx
+++ b/app/components/ControlPanel.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CSS_CLASSES } from '~app/constants';
 import type { SortVariant } from '~app/types';
+import { correctAgeTexts, restoreAgeTexts } from '~app/utils/presenters';
 
 import ControlPanel from './ControlPanel';
 
@@ -18,10 +19,12 @@ vi.mock('~app/utils/presenters', () => ({
   restoreAgeTexts: vi.fn(),
 }));
 
+let mockShowTrueTimeAgo = true;
+
 vi.mock('~app/hooks/useSettings', () => ({
   useSettings: () => {
     const [activeSort, setActiveSort] = useState<SortVariant>('points');
-    return { activeSort, setActiveSort, showTrueTimeAgo: true };
+    return { activeSort, setActiveSort, showTrueTimeAgo: mockShowTrueTimeAgo };
   },
 }));
 
@@ -127,5 +130,17 @@ describe('ControlPanel', () => {
 
     fireEvent.click(screen.getByLabelText('Dismiss'));
     expect(mockDismissPrompt).toHaveBeenCalledOnce();
+  });
+
+  it('should call restoreAgeTexts when showTrueTimeAgo is false', () => {
+    mockShowTrueTimeAgo = false;
+    render(<ControlPanel />);
+    expect(restoreAgeTexts).toHaveBeenCalled();
+    mockShowTrueTimeAgo = true;
+  });
+
+  it('should call correctAgeTexts when showTrueTimeAgo is true', () => {
+    render(<ControlPanel />);
+    expect(correctAgeTexts).toHaveBeenCalled();
   });
 });

--- a/app/components/ControlPanel.tsx
+++ b/app/components/ControlPanel.tsx
@@ -7,13 +7,13 @@ import { useParsedRows } from '~app/hooks/useParsedRows';
 import { useReviewPrompt } from '~app/hooks/useReviewPrompt';
 import { useSettings } from '~app/hooks/useSettings';
 import type { SortVariant } from '~app/types';
-import { updateTable } from '~app/utils/presenters';
+import { correctAgeTexts, restoreAgeTexts, updateTable } from '~app/utils/presenters';
 import { sortRows } from '~app/utils/sorters';
 
 const sortOptionsCount = SORT_OPTIONS.length - 1;
 
 const ControlPanel = (): ReactElement => {
-  const { activeSort, setActiveSort } = useSettings();
+  const { activeSort, setActiveSort, showTrueTimeAgo } = useSettings();
   const { parsedRows, footerRows } = useParsedRows();
   const { showPrompt, dismissPrompt, incrementSortCount } = useReviewPrompt();
 
@@ -21,7 +21,12 @@ const ControlPanel = (): ReactElement => {
 
   useEffect(() => {
     updateTable(sortedRows, footerRows, activeSort);
-  }, [sortedRows, footerRows, activeSort]);
+    if (showTrueTimeAgo) {
+      correctAgeTexts(sortedRows);
+    } else {
+      restoreAgeTexts(sortedRows);
+    }
+  }, [sortedRows, footerRows, activeSort, showTrueTimeAgo]);
 
   const handleSort = useCallback(
     (sortBy: SortVariant) => {

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -13,6 +13,7 @@ export const SETTINGS_KEYS = {
   INSTALL_TIMESTAMP: 'hns-install-ts',
   SORT_COUNT: 'hns-sort-count',
   COOLDOWN: 'hns-cooldown',
+  TRUE_TIME_AGO: 'hns-true-time-ago',
 } as const;
 
 export const SETTINGS_DEFAULTS = {
@@ -23,6 +24,7 @@ export const SETTINGS_DEFAULTS = {
   [SETTINGS_KEYS.INSTALL_TIMESTAMP]: 0 as number,
   [SETTINGS_KEYS.SORT_COUNT]: 0 as number,
   [SETTINGS_KEYS.COOLDOWN]: 3600 as number,
+  [SETTINGS_KEYS.TRUE_TIME_AGO]: true as boolean,
 } as const;
 
 export const COOLDOWN_BOUNDS = {

--- a/app/hooks/useSettings.test.ts
+++ b/app/hooks/useSettings.test.ts
@@ -169,6 +169,22 @@ describe('useSettings', () => {
     });
   });
 
+  describe('TRUE_TIME_AGO watcher', () => {
+    it('should update showTrueTimeAgo from watcher', async () => {
+      setupTableBody([]);
+      const { result } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      expect(result.current.showTrueTimeAgo).toBe(true);
+
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.TRUE_TIME_AGO]?.({ newValue: false });
+      });
+
+      expect(result.current.showTrueTimeAgo).toBe(false);
+    });
+  });
+
   describe('fade interval', () => {
     it('should update opacity on interval tick', async () => {
       setupTableBody(['post-1']);

--- a/app/hooks/useSettings.ts
+++ b/app/hooks/useSettings.ts
@@ -22,10 +22,12 @@ const getPostIdsKey = (): string => `${SETTINGS_KEYS.POST_IDS_PREFIX}${window.lo
 type UseSettingsReturn = {
   activeSort: SortVariant;
   setActiveSort: (sort: SortVariant) => void;
+  showTrueTimeAgo: boolean;
 };
 
 export const useSettings = (): UseSettingsReturn => {
   const [activeSort, setActiveSortState] = useState<SortVariant>(SETTINGS_DEFAULTS[SETTINGS_KEYS.LAST_ACTIVE_SORT]);
+  const [showTrueTimeAgo, setShowTrueTimeAgoState] = useState(SETTINGS_DEFAULTS[SETTINGS_KEYS.TRUE_TIME_AGO]);
   const initializedRef = useRef(false);
   const timestampsRef = useRef<PostTimestamps>({});
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -84,6 +86,9 @@ export const useSettings = (): UseSettingsReturn => {
       const cooldown = await storage.get<number>(SETTINGS_KEYS.COOLDOWN);
       cooldownRef.current = cooldown ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN];
 
+      const trueTimeAgo = await storage.get<boolean>(SETTINGS_KEYS.TRUE_TIME_AGO);
+      setShowTrueTimeAgoState(trueTimeAgo ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.TRUE_TIME_AGO]);
+
       if (isFirstPage()) {
         const stored = await storage.get<string[] | PostTimestamps>(postIdsKey);
         const currentIds = getPostIds();
@@ -136,6 +141,11 @@ export const useSettings = (): UseSettingsReturn => {
           (change.newValue as SortVariant | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.LAST_ACTIVE_SORT],
         );
       },
+      [SETTINGS_KEYS.TRUE_TIME_AGO]: (change) => {
+        setShowTrueTimeAgoState(
+          (change.newValue as boolean | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.TRUE_TIME_AGO],
+        );
+      },
       [SETTINGS_KEYS.COOLDOWN]: (change) => {
         cooldownRef.current = (change.newValue as number | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN];
         if (showNewRef.current && isFirstPage()) {
@@ -174,5 +184,5 @@ export const useSettings = (): UseSettingsReturn => {
     };
   }, []);
 
-  return { activeSort, setActiveSort };
+  return { activeSort, setActiveSort, showTrueTimeAgo };
 };

--- a/app/utils/parsers.test.ts
+++ b/app/utils/parsers.test.ts
@@ -46,53 +46,30 @@ describe('parsers', () => {
   });
 
   describe('getTime', () => {
-    it('should extract timestamp from title attribute (regular post)', () => {
-      // Real HN format: "2026-01-11T18:49:32 1768157372" (ISO datetime + unix timestamp)
-      const isoDate = '2024-01-15T10:30:00';
-      const unixTimestamp = Math.floor(new Date(isoDate).getTime() / 1000);
-      infoRow.innerHTML = `
-        <td class="${HN_CLASSES.SUBTEXT}">
-          <span><span class="${HN_CLASSES.AGE}" title="${isoDate} ${unixTimestamp}">3 hours ago</span></span>
-        </td>
-      `;
-      const result = getTime(infoRow);
-      // Parser splits by space and takes first part (ISO date)
-      expect(result).toBe(new Date(isoDate).getTime());
+    it('should extract unix timestamp from title attribute', () => {
+      // HN title format: "ISO_DATETIME UNIX_TIMESTAMP"
+      infoRow.innerHTML = `<td class="${HN_CLASSES.SUBTEXT}"><span><span class="${HN_CLASSES.AGE}" title="2026-01-11T18:49:32 1768157372">3 hours ago</span></span></td>`;
+      expect(getTime(infoRow)).toBe(1768157372);
     });
 
-    it('should return Infinity when no time element exists', () => {
+    it('should return 0 when no time element exists', () => {
       infoRow.innerHTML = `<td class="${HN_CLASSES.SUBTEXT}"></td>`;
-      expect(getTime(infoRow)).toBe(Infinity);
+      expect(getTime(infoRow)).toBe(0);
     });
 
-    it('should return Infinity when title attribute is missing', () => {
-      infoRow.innerHTML = `
-        <td class="${HN_CLASSES.SUBTEXT}">
-          <span><span class="${HN_CLASSES.AGE}">3 hours ago</span></span>
-        </td>
-      `;
-      expect(getTime(infoRow)).toBe(Infinity);
+    it('should return 0 when title attribute is missing', () => {
+      infoRow.innerHTML = `<td class="${HN_CLASSES.SUBTEXT}"><span><span class="${HN_CLASSES.AGE}">3 hours ago</span></span></td>`;
+      expect(getTime(infoRow)).toBe(0);
     });
 
-    it('should return Infinity for invalid date', () => {
-      infoRow.innerHTML = `
-        <td class="${HN_CLASSES.SUBTEXT}">
-          <span><span class="${HN_CLASSES.AGE}" title="invalid-date">3 hours ago</span></span>
-        </td>
-      `;
-      expect(getTime(infoRow)).toBe(Infinity);
+    it('should return 0 for invalid title format', () => {
+      infoRow.innerHTML = `<td class="${HN_CLASSES.SUBTEXT}"><span><span class="${HN_CLASSES.AGE}" title="invalid-date">3 hours ago</span></span></td>`;
+      expect(getTime(infoRow)).toBe(0);
     });
 
     it('should handle promo posts with different structure', () => {
-      const isoDate = '2024-01-15T10:30:00';
-      const unixTimestamp = Math.floor(new Date(isoDate).getTime() / 1000);
-      infoRow.innerHTML = `
-        <td class="${HN_CLASSES.SUBTEXT}">
-          <span class="${HN_CLASSES.AGE}" title="${isoDate} ${unixTimestamp}">3 hours ago</span>
-        </td>
-      `;
-      const result = getTime(infoRow);
-      expect(result).toBe(new Date(isoDate).getTime());
+      infoRow.innerHTML = `<td class="${HN_CLASSES.SUBTEXT}"><span class="${HN_CLASSES.AGE}" title="2026-01-11T18:49:32 1768157372">3 hours ago</span></td>`;
+      expect(getTime(infoRow)).toBe(1768157372);
     });
   });
 

--- a/app/utils/parsers.ts
+++ b/app/utils/parsers.ts
@@ -1,6 +1,8 @@
 import { stringToNumber } from '~app/utils/converters';
 import { getCommentsElement, getPointsElement, getTimeElement } from '~app/utils/selectors';
 
+const TITLE_UNIX_TS_INDEX = 1;
+
 export const getPoints = (infoRow: HTMLElement): number => {
   const pointsElement = getPointsElement(infoRow);
 
@@ -13,24 +15,13 @@ export const getPoints = (infoRow: HTMLElement): number => {
 
 export const getTime = (infoRow: HTMLElement): number => {
   const timeElement = getTimeElement(infoRow);
-
-  if (!timeElement) {
-    return Infinity;
-  }
+  if (!timeElement) return 0;
 
   const title = timeElement.getAttribute('title');
+  if (!title) return 0;
 
-  if (!title) {
-    return Infinity;
-  }
-
-  const time = new Date(title.split(' ')[0]).getTime();
-
-  if (isNaN(time)) {
-    return Infinity;
-  }
-
-  return time;
+  const unixTs = parseInt(title.split(' ')[TITLE_UNIX_TS_INDEX]);
+  return isNaN(unixTs) ? 0 : unixTs;
 };
 
 export const getComments = (infoRow: HTMLElement): number => {

--- a/app/utils/presenters.test.ts
+++ b/app/utils/presenters.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CSS_CLASSES, HN_CLASSES } from '~app/constants';
+import type { ParsedRow } from '~app/types';
 
-import { highlightActiveSort } from './presenters';
+import { correctAgeTexts, formatAge, highlightActiveSort, restoreAgeTexts } from './presenters';
 
 describe('presenters', () => {
   describe('highlightActiveSort', () => {
@@ -85,6 +86,85 @@ describe('presenters', () => {
       const highlighted = infoRow.querySelectorAll(`.${CSS_CLASSES.HIGHLIGHT}`);
       expect(highlighted.length).toBe(1);
       expect(highlighted[0].classList.contains(HN_CLASSES.SCORE)).toBe(true);
+    });
+  });
+
+  describe('formatAge', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-24T12:00:00Z'));
+    });
+    afterEach(() => vi.useRealTimers());
+
+    const nowSec = Math.floor(new Date('2026-03-24T12:00:00Z').getTime() / 1000);
+
+    it('should format minutes', () => expect(formatAge(nowSec - 30 * 60)).toBe('30 minutes ago'));
+    it('should format singular minute', () => expect(formatAge(nowSec - 60)).toBe('1 minute ago'));
+    it('should format hours', () => expect(formatAge(nowSec - 5 * 3600)).toBe('5 hours ago'));
+    it('should format singular hour', () => expect(formatAge(nowSec - 3600)).toBe('1 hour ago'));
+    it('should format days', () => expect(formatAge(nowSec - 3 * 86400)).toBe('3 days ago'));
+    it('should format singular day', () => expect(formatAge(nowSec - 86400)).toBe('1 day ago'));
+    it('should use days for 25 hours', () => expect(formatAge(nowSec - 25 * 3600)).toBe('1 day ago'));
+    it('should handle future timestamps', () => expect(formatAge(nowSec + 100)).toBe('0 minutes ago'));
+  });
+
+  describe('correctAgeTexts / restoreAgeTexts', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-24T12:00:00Z'));
+    });
+    afterEach(() => vi.useRealTimers());
+
+    const makeRow = (ageText: string, unixTs: number): ParsedRow => {
+      const info = document.createElement('tr');
+      const td = document.createElement('td');
+      td.className = HN_CLASSES.SUBTEXT;
+      const span = document.createElement('span');
+      const ageSpan = document.createElement('span');
+      ageSpan.className = HN_CLASSES.AGE;
+      ageSpan.setAttribute('title', `2026-01-01T00:00:00 ${unixTs}`);
+      const link = document.createElement('a');
+      link.href = 'item?id=1';
+      link.textContent = ageText;
+      ageSpan.appendChild(link);
+      span.appendChild(ageSpan);
+      td.appendChild(span);
+      info.appendChild(td);
+      return {
+        originalIndex: 0,
+        title: document.createElement('tr'),
+        info,
+        spacer: document.createElement('tr'),
+        points: 0,
+        time: unixTs,
+        comments: 0,
+      };
+    };
+
+    it('should correct age text and preserve link', () => {
+      const nowSec = Math.floor(Date.now() / 1000);
+      const row = makeRow('14 hours ago', nowSec - 3 * 86400);
+      correctAgeTexts([row]);
+      const link = row.info.querySelector('a')!;
+      expect(link.textContent).toBe('3 days ago');
+      expect(link.getAttribute('href')).toBe('item?id=1');
+    });
+
+    it('should save original text in data attribute', () => {
+      const nowSec = Math.floor(Date.now() / 1000);
+      const row = makeRow('14 hours ago', nowSec - 3 * 86400);
+      correctAgeTexts([row]);
+      expect(row.info.querySelector('a')!.getAttribute('data-original-age')).toBe('14 hours ago');
+    });
+
+    it('should restore original text', () => {
+      const nowSec = Math.floor(Date.now() / 1000);
+      const row = makeRow('14 hours ago', nowSec - 3 * 86400);
+      correctAgeTexts([row]);
+      restoreAgeTexts([row]);
+      const link = row.info.querySelector('a')!;
+      expect(link.textContent).toBe('14 hours ago');
+      expect(link.hasAttribute('data-original-age')).toBe(false);
     });
   });
 });

--- a/app/utils/presenters.test.ts
+++ b/app/utils/presenters.test.ts
@@ -166,5 +166,32 @@ describe('presenters', () => {
       expect(link.textContent).toBe('14 hours ago');
       expect(link.hasAttribute('data-original-age')).toBe(false);
     });
+
+    it('should skip rows with time === 0', () => {
+      const row = makeRow('3 hours ago', 0);
+      row.time = 0;
+      correctAgeTexts([row]);
+      expect(row.info.querySelector('a')!.textContent).toBe('3 hours ago');
+    });
+
+    it('should skip rows without a link inside .age', () => {
+      const row = makeRow('3 hours ago', Math.floor(Date.now() / 1000) - 86400);
+      row.info.querySelector('a')!.remove();
+      expect(() => correctAgeTexts([row])).not.toThrow();
+    });
+
+    it('should not overwrite already-saved original text on repeated calls', () => {
+      const nowSec = Math.floor(Date.now() / 1000);
+      const row = makeRow('14 hours ago', nowSec - 3 * 86400);
+      correctAgeTexts([row]);
+      correctAgeTexts([row]);
+      expect(row.info.querySelector('a')!.getAttribute('data-original-age')).toBe('14 hours ago');
+    });
+
+    it('restoreAgeTexts should be a no-op when no original was saved', () => {
+      const row = makeRow('3 hours ago', Math.floor(Date.now() / 1000) - 3600);
+      restoreAgeTexts([row]);
+      expect(row.info.querySelector('a')!.textContent).toBe('3 hours ago');
+    });
   });
 });

--- a/app/utils/presenters.ts
+++ b/app/utils/presenters.ts
@@ -2,6 +2,8 @@ import { CSS_CLASSES, CSS_SELECTORS } from '~app/constants';
 import type { NonDefaultSortVariant, ParsedRow, SortVariant } from '~app/types';
 import { getCommentsElement, getPointsElement, getTableBody, getTimeElement } from '~app/utils/selectors';
 
+const DATA_ORIGINAL_AGE = 'data-original-age';
+
 export const updateTable = (parsedRows: ParsedRow[], footerRows: HTMLElement[], activeSort: SortVariant): void => {
   if (parsedRows.length === 0) return;
 
@@ -48,4 +50,46 @@ export const highlightActiveSort = (infoRow: HTMLElement, activeSort: SortVarian
   }
 
   return infoRow;
+};
+
+const pluralize = (count: number, singular: string): string => `${count} ${count === 1 ? singular : singular + 's'}`;
+
+export const formatAge = (unixTimestamp: number): string => {
+  const secondsAgo = Math.floor(Date.now() / 1000) - unixTimestamp;
+  if (secondsAgo < 0) return '0 minutes ago';
+
+  const days = Math.floor(secondsAgo / 86400);
+  if (days > 0) return `${pluralize(days, 'day')} ago`;
+
+  const hours = Math.floor(secondsAgo / 3600);
+  if (hours > 0) return `${pluralize(hours, 'hour')} ago`;
+
+  const minutes = Math.floor(secondsAgo / 60);
+  return `${pluralize(minutes, 'minute')} ago`;
+};
+
+export const correctAgeTexts = (parsedRows: ParsedRow[]): void => {
+  for (const row of parsedRows) {
+    if (row.time === 0) continue;
+    const ageEl = getTimeElement(row.info);
+    const link = ageEl?.querySelector('a');
+    if (!link) continue;
+    if (!link.hasAttribute(DATA_ORIGINAL_AGE)) {
+      link.setAttribute(DATA_ORIGINAL_AGE, link.textContent ?? '');
+    }
+    link.textContent = formatAge(row.time);
+  }
+};
+
+export const restoreAgeTexts = (parsedRows: ParsedRow[]): void => {
+  for (const row of parsedRows) {
+    const ageEl = getTimeElement(row.info);
+    const link = ageEl?.querySelector('a');
+    if (!link) continue;
+    const original = link.getAttribute(DATA_ORIGINAL_AGE);
+    if (original !== null) {
+      link.textContent = original;
+      link.removeAttribute(DATA_ORIGINAL_AGE);
+    }
+  }
 };

--- a/app/utils/selectors.integration.test.ts
+++ b/app/utils/selectors.integration.test.ts
@@ -58,5 +58,23 @@ describe('selectors (integration with live HN HTML)', () => {
     expect(commentsCount, `at least ${minWithElement}/${rowCount} should have COMMENTS`).toBeGreaterThanOrEqual(
       minWithElement,
     );
+
+    // Canary: validate HN's .age title attribute format ("ISO_DATETIME UNIX_TIMESTAMP")
+    const titleFormatRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} \d+$/;
+    infoRows.forEach((row) => {
+      const ageEl = getTimeElement(row);
+      if (!ageEl) return;
+      const title = ageEl.getAttribute('title');
+      expect(title, 'age title should match "ISO UNIX" format').toMatch(titleFormatRegex);
+    });
+
+    // Canary: validate HN's .age text format ("X minute(s)/hour(s)/day(s) ago")
+    const ageTextRegex = /^\d+ (minute|hour|day)s? ago$/;
+    infoRows.forEach((row) => {
+      const ageEl = getTimeElement(row);
+      if (!ageEl) return;
+      const text = ageEl.textContent?.trim();
+      expect(text, 'age text should match "N unit(s) ago" format').toMatch(ageTextRegex);
+    });
   });
 });

--- a/popup.tsx
+++ b/popup.tsx
@@ -6,14 +6,14 @@ import { COOLDOWN_BOUNDS, CWS_REVIEW_URL, SETTINGS_DEFAULTS, SETTINGS_KEYS } fro
 
 import './popup.css';
 
+type SettingsKey = keyof typeof SETTINGS_DEFAULTS;
+const useSettingsStorage = <K extends SettingsKey>(key: K) => useStorage(key, SETTINGS_DEFAULTS[key]);
+
 const Popup = () => {
-  const [showNew, setShowNew] = useStorage(SETTINGS_KEYS.SHOW_NEW, SETTINGS_DEFAULTS[SETTINGS_KEYS.SHOW_NEW]);
-  const [cooldown, setCooldown] = useStorage(SETTINGS_KEYS.COOLDOWN, SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN]);
-  const [trueTimeAgo, setTrueTimeAgo] = useStorage(
-    SETTINGS_KEYS.TRUE_TIME_AGO,
-    SETTINGS_DEFAULTS[SETTINGS_KEYS.TRUE_TIME_AGO],
-  );
-  const [layoutOk] = useStorage(SETTINGS_KEYS.LAYOUT_OK, SETTINGS_DEFAULTS[SETTINGS_KEYS.LAYOUT_OK]);
+  const [showNew, setShowNew] = useSettingsStorage(SETTINGS_KEYS.SHOW_NEW);
+  const [cooldown, setCooldown] = useSettingsStorage(SETTINGS_KEYS.COOLDOWN);
+  const [trueTimeAgo, setTrueTimeAgo] = useSettingsStorage(SETTINGS_KEYS.TRUE_TIME_AGO);
+  const [layoutOk] = useSettingsStorage(SETTINGS_KEYS.LAYOUT_OK);
   // useStorage renders with the default value first, then async-loads the stored value.
   // When stored !== default, the CSS transition animates the toggle visibly (on→off flash).
   // Suppress transitions for 50ms to let storage settle, then re-enable for user interactions.

--- a/popup.tsx
+++ b/popup.tsx
@@ -9,6 +9,10 @@ import './popup.css';
 const Popup = () => {
   const [showNew, setShowNew] = useStorage(SETTINGS_KEYS.SHOW_NEW, SETTINGS_DEFAULTS[SETTINGS_KEYS.SHOW_NEW]);
   const [cooldown, setCooldown] = useStorage(SETTINGS_KEYS.COOLDOWN, SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN]);
+  const [trueTimeAgo, setTrueTimeAgo] = useStorage(
+    SETTINGS_KEYS.TRUE_TIME_AGO,
+    SETTINGS_DEFAULTS[SETTINGS_KEYS.TRUE_TIME_AGO],
+  );
   const [layoutOk] = useStorage(SETTINGS_KEYS.LAYOUT_OK, SETTINGS_DEFAULTS[SETTINGS_KEYS.LAYOUT_OK]);
   // useStorage renders with the default value first, then async-loads the stored value.
   // When stored !== default, the CSS transition animates the toggle visibly (on→off flash).
@@ -71,6 +75,20 @@ const Popup = () => {
           />
         </div>
       )}
+
+      <div className="hns-setting">
+        <span>Show true time ago</span>
+        <label className="hns-toggle">
+          <input
+            type="checkbox"
+            name="true-time-ago"
+            aria-label="Show true time ago"
+            checked={trueTimeAgo}
+            onChange={(e) => setTrueTimeAgo(e.target.checked)}
+          />
+          <span className="hns-toggle-slider" />
+        </label>
+      </div>
 
       <div className="hns-review-link">
         Enjoying HN Sorted?{' '}


### PR DESCRIPTION
## Summary
- Switch `getTime()` from ISO date parsing to Unix timestamp from the title attribute — simpler and timezone-safe
- Add "true time ago" feature that corrects misleading HN age text for "second chance" posts (e.g., "7 hours ago" → "3 days ago"), with a toggle in popup settings (on by default)
- Add HN format canary tests in the integration test to detect title attribute or age text format changes

## Test plan
- [x] All 170 tests pass (`bun run test`)
- [x] Lint clean (`bun run lint`)
- [x] Verified in browser: second-chance post ages corrected, time sort order matches displayed text
- [x] Toggle off in popup reverts to original HN text
- [x] Verify on fresh Chrome profile