### PR TITLE
feat(popup): redesign settings with grouped layout and hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Redesigned popup settings with grouped layout — dependent settings (new posts + highlight duration) are visually connected, independent settings are separated
+- Renamed "Fade duration" to "Highlight duration" for clarity
+- Added hint descriptions below each setting
+
 ### Added
 
 - New post indicator cooldown with opacity fade — indicators persist across reloads and fade out over a configurable period (default 60 min, range 10s–24h)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Redesigned popup settings with grouped layout — dependent settings (new posts + highlight duration) are visually connected, independent settings are separated
-- Renamed "Fade duration" to "Highlight duration" for clarity
-- Added hint descriptions below each setting
-
 ### Added
 
 - New post indicator cooldown with opacity fade — indicators persist across reloads and fade out over a configurable period (default 60 min, range 10s–24h)
@@ -26,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Redesigned popup settings with grouped layout — dependent settings (new posts + highlight duration) are visually connected, independent settings are separated
+- Renamed "Fade duration" to "Highlight duration" for clarity
+- Added hint descriptions below each setting
 - Rewrite Chrome Web Store description for better discoverability
 - Time sorting now uses Unix timestamp from title attribute instead of ISO date parsing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,8 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
 
 ### Popup Entry Point
 
-- `popup.tsx` - Settings popup UI with toggle switch for new-post indicators and cooldown number input; shows a warning banner when layout detection fails
-- `popup.css` - Popup styles (toggle switches, layout, warning banner)
+- `popup.tsx` - Settings popup UI with grouped layout: dependent settings (new-post toggle + highlight duration) share a `fieldset.hns-group`, independent settings get separate groups; each setting has a `hns-hint` description; shows a warning banner when layout detection fails
+- `popup.css` - Popup styles (toggle switches, setting groups, hints, warning banner)
 - Uses `useSettingsStorage` helper — a typed wrapper around `useStorage` that auto-resolves defaults from `SETTINGS_DEFAULTS`
 
 ### Component Structure

--- a/app/popup.test.tsx
+++ b/app/popup.test.tsx
@@ -59,7 +59,7 @@ describe('Popup', () => {
     storageValues = { [SETTINGS_KEYS.SHOW_NEW]: true };
     render(<Popup />);
 
-    const input = screen.getByLabelText('Fade duration in seconds');
+    const input = screen.getByLabelText('Highlight duration in seconds');
     expect(input).toBeInTheDocument();
     expect(input).toHaveAttribute('type', 'number');
     expect(input).toHaveAttribute('min', String(COOLDOWN_BOUNDS.MIN));
@@ -70,14 +70,14 @@ describe('Popup', () => {
     storageValues = { [SETTINGS_KEYS.SHOW_NEW]: false };
     render(<Popup />);
 
-    expect(screen.queryByLabelText('Fade duration in seconds')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Highlight duration in seconds')).not.toBeInTheDocument();
   });
 
   it('should display default cooldown value', () => {
     storageValues = { [SETTINGS_KEYS.SHOW_NEW]: true, [SETTINGS_KEYS.COOLDOWN]: 300 };
     render(<Popup />);
 
-    const input = screen.getByLabelText('Fade duration in seconds') as HTMLInputElement;
+    const input = screen.getByLabelText('Highlight duration in seconds') as HTMLInputElement;
     expect(input.value).toBe('300');
   });
 });

--- a/popup.css
+++ b/popup.css
@@ -4,7 +4,7 @@ body {
   color: #222;
   margin: 0;
   padding: 12px 16px;
-  min-width: 200px;
+  min-width: 300px;
 }
 
 h1 {
@@ -21,8 +21,34 @@ h1 {
   padding: 6px 0;
 }
 
-.hns-setting + .hns-setting {
-  border-top: 1px solid #f0f0f0;
+/* Setting groups */
+.hns-group {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.hns-group + .hns-group {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.hns-setting-label {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.hns-hint {
+  font-size: 10px;
+  color: #999;
+  margin-top: 2px;
+  line-height: 1.3;
+}
+
+.hns-setting-child {
+  padding-left: 12px;
 }
 
 .hns-toggle {
@@ -110,7 +136,7 @@ h1 {
 /* Persistent review link */
 .hns-review-link {
   margin-top: 12px;
-  padding-top: 8px;
+  padding-top: 12px;
   border-top: 1px solid #e0e0e0;
   font-size: 10px;
   color: #999;

--- a/popup.tsx
+++ b/popup.tsx
@@ -38,57 +38,70 @@ const Popup = () => {
         </div>
       )}
 
-      <div className="hns-setting">
-        <span>Highlight new posts</span>
-        <label className="hns-toggle">
-          <input
-            type="checkbox"
-            name="show-new"
-            aria-label="Highlight new posts"
-            checked={showNew}
-            onChange={(e) => setShowNew(e.target.checked)}
-          />
-          <span className="hns-toggle-slider" />
-        </label>
-      </div>
-
-      {showNew && (
+      <fieldset className="hns-group">
         <div className="hns-setting">
-          <span>Fade duration (sec)</span>
-          <input
-            type="number"
-            name="cooldown"
-            aria-label="Fade duration in seconds"
-            min={COOLDOWN_BOUNDS.MIN}
-            max={COOLDOWN_BOUNDS.MAX}
-            value={cooldown}
-            onChange={(e) => setCooldown(Number(e.target.value))}
-            onBlur={(e) =>
-              setCooldown(
-                Math.max(
-                  COOLDOWN_BOUNDS.MIN,
-                  Math.min(COOLDOWN_BOUNDS.MAX, Number(e.target.value) || SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN]),
-                ),
-              )
-            }
-            className="hns-number-input"
-          />
+          <div className="hns-setting-label">
+            <span>Highlight new posts</span>
+            <span className="hns-hint">Mark posts added since your last visit</span>
+          </div>
+          <label className="hns-toggle">
+            <input
+              type="checkbox"
+              name="show-new"
+              aria-label="Highlight new posts"
+              checked={showNew}
+              onChange={(e) => setShowNew(e.target.checked)}
+            />
+            <span className="hns-toggle-slider" />
+          </label>
         </div>
-      )}
 
-      <div className="hns-setting">
-        <span>Show true time ago</span>
-        <label className="hns-toggle">
-          <input
-            type="checkbox"
-            name="true-time-ago"
-            aria-label="Show true time ago"
-            checked={trueTimeAgo}
-            onChange={(e) => setTrueTimeAgo(e.target.checked)}
-          />
-          <span className="hns-toggle-slider" />
-        </label>
-      </div>
+        {showNew && (
+          <div className="hns-setting hns-setting-child">
+            <div className="hns-setting-label">
+              <span>Highlight duration in seconds</span>
+              <span className="hns-hint">How long the indicator stays visible</span>
+            </div>
+            <input
+              type="number"
+              name="cooldown"
+              aria-label="Highlight duration in seconds"
+              min={COOLDOWN_BOUNDS.MIN}
+              max={COOLDOWN_BOUNDS.MAX}
+              value={cooldown}
+              onChange={(e) => setCooldown(Number(e.target.value))}
+              onBlur={(e) =>
+                setCooldown(
+                  Math.max(
+                    COOLDOWN_BOUNDS.MIN,
+                    Math.min(COOLDOWN_BOUNDS.MAX, Number(e.target.value) || SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN]),
+                  ),
+                )
+              }
+              className="hns-number-input"
+            />
+          </div>
+        )}
+      </fieldset>
+
+      <fieldset className="hns-group">
+        <div className="hns-setting">
+          <div className="hns-setting-label">
+            <span>Show true &ldquo;time ago&rdquo;</span>
+            <span className="hns-hint">Fix misleading ages on resurfaced posts</span>
+          </div>
+          <label className="hns-toggle">
+            <input
+              type="checkbox"
+              name="true-time-ago"
+              aria-label="Show true time ago setting"
+              checked={trueTimeAgo}
+              onChange={(e) => setTrueTimeAgo(e.target.checked)}
+            />
+            <span className="hns-toggle-slider" />
+          </label>
+        </div>
+      </fieldset>
 
       <div className="hns-review-link">
         Enjoying HN Sorted?{' '}


### PR DESCRIPTION
## Summary
- Group dependent settings (new posts toggle + highlight duration) in a shared `fieldset`, visually connecting parent-child settings
- Separate independent settings (true time ago) into their own group with a subtle border divider
- Add hint descriptions below each setting label explaining what the option does
- Rename "Fade duration" → "Highlight duration" for clarity
- Widen popup from 200px to 300px min-width for better readability

## Test plan
- [x] Open extension popup — verify grouped layout with indented child setting
- [x] Toggle "Highlight new posts" off — highlight duration input hides
- [x] Toggle it back on — input reappears within the same group
- [x] Verify hint texts render below each setting label
- [x] `bun run test` passes (177/177)
- [x] `bun run lint` passes