### PR TITLE
feat(sorts): add velocity and heat derived sorts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,6 @@ dist/
 *.tsbuildinfo
 
 .plans/
+.compound-engineering/
 docs/
+CONCEPTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Two new sort options: **Velocity** (fastest-rising posts — points per hour, damped so young posts earn their rank) and **Heat** (most-discussed — comments per point), with hotkeys V and H
 - Per-sort toggles in the popup to disable Velocity and/or Heat individually (both on by default, synced across devices)
-- Three-tier responsive sort menu: full names on wide screens, single-letter labels on medium screens, and a "Sort by" dropdown on small/mobile screens; the full-name breakpoint adapts to how many sorts are enabled
+- Three-tier responsive sort menu: full names on wide screens, single-letter labels on medium screens, and a compact dropdown on narrow screens; every breakpoint adapts to how many sorts are enabled and is tuned so the menu always collapses to a smaller tier before it would push Hacker News's own header links onto a second line
 - Hotkey conflict note: when another extension (e.g. Vimium) intercepts a sort key, the menu now names the specific keys affected
 - Settings popup now follows the system light/dark color scheme
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Two new sort options: **Velocity** (fastest-rising posts — points per hour, damped so young posts earn their rank) and **Heat** (most-discussed — comments per point), with hotkeys V and H
+- Per-sort toggles in the popup to disable Velocity and/or Heat individually (both on by default, synced across devices)
+- Three-tier responsive sort menu: full names on wide screens, single-letter labels on medium screens, and a "Sort by" dropdown on small/mobile screens; the full-name breakpoint adapts to how many sorts are enabled
+- Hotkey conflict note: when another extension (e.g. Vimium) intercepts a sort key, the menu now names the specific keys affected
 - Settings popup now follows the system light/dark color scheme
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Hacker News Sorted is a Chrome extension that adds sorting capabilities to Hacker News (news.ycombinator.com). Users can sort posts by points, time, comments, or restore the default order. Built with Plasmo framework and React.
+Hacker News Sorted is a Chrome extension that adds sorting capabilities to Hacker News (news.ycombinator.com). Users can sort posts by points, time, comments, velocity, heat, or restore the default order. Built with Plasmo framework and React.
 
 ## Commands
 
@@ -28,7 +28,7 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
 ### Content Script Entry Point
 
 - `content.tsx` - Main entry point, injects the ControlPanel into HN's header using Plasmo's content script UI lifecycle
-- `content.css` - Styles for the control panel, sort highlighting, and new-post indicators
+- `content.css` - Styles for the control panel, sort highlighting, and new-post indicators. Three-tier responsive menu: full names on wide screens, single-letter labels on medium, and a native `<select>` dropdown tier on tiny/mobile screens. The word↔letter switch is count-aware — one `@media` block per enabled-option count (4/5/6) keyed on the `#hns-control-panel[data-sort-count='N']` attribute (1280/1360/1440px, calibrated against HN's header); the dropdown tier is a fixed `max-width: 600px` breakpoint that hides `.hns-buttons-tier` and shows `.hns-dropdown-tier`
 - Detects layout breakage: writes `hns-layout-ok` to `chrome.storage.sync` based on whether expected DOM elements are found (with a 3-second timeout)
 - **Dev gotcha**: Plasmo hot-reload often doesn't pick up content script CSS or `useState` initial value changes — reload the HN page (or the extension itself) to see updates
 
@@ -40,36 +40,37 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
 
 ### Popup Entry Point
 
-- `popup.tsx` - Settings popup UI with grouped layout: dependent settings (new-post toggle + highlight duration) share a `fieldset.hns-group`, independent settings get separate groups; each setting has a `hns-hint` description; shows a warning banner when layout detection fails
+- `popup.tsx` - Settings popup UI with grouped layout: dependent settings (new-post toggle + highlight duration) share a `fieldset.hns-group`, independent settings get separate groups; each setting has a `hns-hint` description; shows a warning banner when layout detection fails. Includes per-sort toggles for Velocity and Heat (both default on)
 - `popup.css` - Popup styles (toggle switches, setting groups, hints, warning banner); follows system light/dark via `color-scheme: light dark` + semantic CSS custom properties overridden in a `@media (prefers-color-scheme: dark)` block (brand `#ff6600` unchanged across schemes)
 - Uses `useSettingsStorage` helper — a typed wrapper around `useStorage` that auto-resolves defaults from `SETTINGS_DEFAULTS`
 
 ### Component Structure
 
-- `app/components/ControlPanel.tsx` - Main UI component with sort buttons, consumes sort state from `useSettings` hook
-- `app/components/SortButton.tsx` - Individual sort option buttons (points/time/comments/default)
+- `app/components/ControlPanel.tsx` - Main UI component, consumes sort state + `enabledSortOptions` + `settled` from `useSettings`. Maps over the enabled options (buttons + separators, plus a native `<select>` for the mobile dropdown tier), gates first paint on `settled` (KTD-8), publishes the enabled-option count on the panel root via the `data-sort-count` attribute for count-aware CSS breakpoints (KTD-3), and renders a `role="status"` conflict note listing intercepted hotkeys when `useKeyboardShortcuts` reports any (KTD-5)
+- `app/components/SortButton.tsx` - Individual sort option buttons (points/time/comments/velocity/heat/default)
 
 ### Data Flow
 
-1. `useSettings` hook reads sort preference and post IDs from `chrome.storage.sync`, marks new posts, exposes reactive `activeSort`
+1. `useSettings` hook reads sort preference and post IDs from `chrome.storage.sync`, marks new posts, exposes reactive `activeSort`, the derived `enabledSortOptions` list, and a `settled` first-paint flag; validates `activeSort` against the enabled set (unknown/disabled → `default`, R6)
 2. `useParsedRows` hook extracts post data from HN's DOM on mount (title, info, spacer rows per post)
-3. `sortRows` creates a new sorted array based on active sort option
-4. `updateTable` replaces the table body with reordered rows and highlights the active sort column
+3. `sortRows` creates a new sorted array based on active sort option (velocity/heat are computed at sort time, not stored)
+4. `updateTable` replaces the table body with reordered rows and highlights the active sort column (velocity/heat span two columns, so they highlight nothing — KTD-2)
 
 ### Key Utils
 
 - `app/utils/selectors.ts` - DOM selectors for HN's table structure (title rows at 3n+1, info rows at 3n+2, spacer rows at 3n+3)
 - `app/utils/parsers.ts` - Extract numeric values (points, time, comments) from info rows; `getTime` parses the Unix timestamp (second part) from the `.age` title attribute (`"ISO_DATETIME UNIX_TIMESTAMP"`)
 - `app/utils/converters.ts` - `stringToNumber` (parseInt wrapper), `nowInSeconds` (current epoch in seconds — use instead of inline `Math.floor(Date.now() / 1000)`)
-- `app/utils/sorters.ts` - Sort functions for each sort variant
-- `app/utils/presenters.ts` - DOM manipulation to update table, highlight active sort column, and correct age text (`formatAge`, `correctAgeTexts`, `restoreAgeTexts`)
+- `app/utils/sorters.ts` - Sort functions for each sort variant; velocity = `points / (ageHours + 2)` (damped), heat = `comments / points` with a below-zero sentinel for 0-points rows so job posts sink without `Infinity`/`NaN`
+- `app/utils/presenters.ts` - DOM manipulation to update table, highlight active sort column, and correct age text (`formatAge`, `correctAgeTexts`, `restoreAgeTexts`); `highlightActiveSort` early-returns for any variant without a column getter (default/velocity/heat/unknown), which also removes the cross-version crash from an unmapped variant arriving via sync
 - `app/utils/newPosts.ts` - New post detection and fade: exports `PostTimestamps` type, `migratePostIds`, `markNewPosts` (with cooldown-aware opacity), `updateFadeOpacities`, `clearNewPostMarkers`, `isFirstPage`
 
 ### Keyboard Shortcuts
 
 - `app/hooks/useKeyboardShortcuts.ts` - Keyboard event handler with Vimium conflict detection
-- Keys: P (points), T (time), C (comments), D (default)
-- Auto-disables if another extension (e.g., Vimium) handles any of the keys
+- Keys: P (points), T (time), C (comments), V (velocity), H (heat), D (default)
+- Takes `enabledSortOptions` and derives the live key set — a disabled sort's key is inert (skipped before conflict detection, so it neither sorts nor flags a conflict)
+- Auto-disables ALL shortcuts if another extension (e.g., Vimium) handles any of the keys; returns the accumulated set of conflicting keys (React state) so `ControlPanel` can name them in the conflict note (KTD-5)
 
 ### Settings & New Post Detection
 
@@ -79,6 +80,8 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
   - Show-new toggle — applies/removes `hns-show-new` CSS class on table body
   - Fade interval — drives `--hns-fade` CSS custom property on new-post rows, with cooldown/showNew-aware lifecycle and memory leak guards (`mountedRef`, `intervalRef`, `showNewRef`)
   - True time ago toggle (`showTrueTimeAgo`) — exposes reactive boolean for age text correction
+  - Velocity/Heat enabled toggles — derive `enabledSortOptions` (the SORT_OPTIONS subset the panel, dropdown, and hotkeys all consume); validated in the init read and both watchers (last-active-sort + toggle changes) via `resolveActiveSort`, which resolves unknown/disabled sorts to `default` locally without writing back (KTD-6, no ping-pong). Ref mirrors (`velocityEnabledRef`/`heatEnabledRef`) keep watchers validating against current state
+  - `settled` flag — flips after the async init read so the panel doesn't flash a six-option layout before reflowing (KTD-8)
 - All settings sync across devices via `chrome.storage.sync`
 - New-post detection only runs on first pages (skips paginated pages with `?p=...` or `?next=...`)
 
@@ -99,11 +102,11 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
 ### Constants
 
 - `app/constants.ts` - Centralized constants including:
-  - Extension constants (`CONTROL_PANEL_ROOT_ID`)
-  - `CSS_CLASSES` - Extension CSS class names (highlight, buttons, labels, `SHOW_NEW`, `NEW_POST`)
+  - Extension constants (`CONTROL_PANEL_ROOT_ID`, `SORT_COUNT_ATTR` — the `data-sort-count` attribute driving count-aware CSS breakpoints)
+  - `CSS_CLASSES` - Extension CSS class names (highlight, buttons, labels, `SHOW_NEW`, `NEW_POST`, `CONFLICT_NOTE`, `BUTTONS_TIER`, `DROPDOWN_TIER`, `DROPDOWN_LABEL`, `DROPDOWN`)
   - `CSS_SELECTORS` - Derived CSS selectors from class names
-  - `SORT_OPTIONS` - Sort option configuration array (sort variant, display text, keyboard shortcut)
-  - `SETTINGS_KEYS` - Storage key names for chrome.storage.sync (`SHOW_NEW`, `LAST_ACTIVE_SORT`, `POST_IDS_PREFIX`, `COOLDOWN`, `TRUE_TIME_AGO`)
+  - `SORT_OPTIONS` - Sort option configuration array (sort variant, display text, keyboard shortcut); order: points, time, comments, velocity, heat, default
+  - `SETTINGS_KEYS` - Storage key names for chrome.storage.sync (`SHOW_NEW`, `LAST_ACTIVE_SORT`, `POST_IDS_PREFIX`, `COOLDOWN`, `TRUE_TIME_AGO`, `VELOCITY_ENABLED`, `HEAT_ENABLED`)
   - `SETTINGS_DEFAULTS` - Default values for settings
   - `COOLDOWN_BOUNDS` - Min/max bounds for cooldown input validation
   - `SECONDS_PER_MINUTE`, `SECONDS_PER_HOUR`, `SECONDS_PER_DAY` - Time unit constants (used in presenters and tests)
@@ -112,7 +115,7 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
 
 ### Types
 
-- `SortVariant`: 'default' | 'points' | 'time' | 'comments'
+- `SortVariant`: 'default' | 'points' | 'time' | 'comments' | 'velocity' | 'heat'
 - `ParsedRow`: Contains DOM elements (title, info, spacer) and parsed numeric values for a single post
 - `PostTimestamps`: `Record<string, number>` — post ID → discovery timestamp (`Date.now()`), or `-1` for known/never-new posts (exported from `app/utils/newPosts.ts`)
 - `Settings`: Shape for extension settings (`hns-show-new` boolean, `hns-last-active-sort` SortVariant)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
 ### Content Script Entry Point
 
 - `content.tsx` - Main entry point, injects the ControlPanel into HN's header using Plasmo's content script UI lifecycle
-- `content.css` - Styles for the control panel, sort highlighting, and new-post indicators. Three-tier responsive menu: full names on wide screens, single-letter labels on medium, and a native `<select>` dropdown tier on tiny/mobile screens. The word↔letter switch is count-aware — one `@media` block per enabled-option count (4/5/6) keyed on the `#hns-control-panel[data-sort-count='N']` attribute (1280/1360/1440px, calibrated against HN's header); the dropdown tier is a fixed `max-width: 600px` breakpoint that hides `.hns-buttons-tier` and shows `.hns-dropdown-tier`
+- `content.css` - Styles for the control panel, sort highlighting, and new-post indicators. Three-tier responsive menu: full names on wide screens, single-letter labels on medium, and a native `<select>` dropdown tier on narrow screens. **Both** tier switches are count-aware — one `@media` block per enabled-option count (4/5/6) keyed on the `#hns-control-panel[data-sort-count='N']` attribute — because each tier's width, and thus the point at which it would push HN's own header nav onto a second line, grows with the option count. Word↔letter (`min-width` 1280/1360/1440px); letter↔dropdown (`max-width` 1080/1120/1160px) hides `.hns-buttons-tier` and shows `.hns-dropdown-tier`. All breakpoints are calibrated against HN's header so the menu always collapses to a more compact tier _before_ it would wrap HN's nav (measured letter-row wrap floors ~1044/1084/1124px; the dropdown has no visible label so it stays as narrow as HN's own ~750px nav-wrap floor)
 - Detects layout breakage: writes `hns-layout-ok` to `chrome.storage.sync` based on whether expected DOM elements are found (with a 3-second timeout)
 - **Dev gotcha**: Plasmo hot-reload often doesn't pick up content script CSS or `useState` initial value changes — reload the HN page (or the extension itself) to see updates
 
@@ -103,7 +103,7 @@ bun run demo           # Generate demo video (.mp4) and GIF (requires `bun run b
 
 - `app/constants.ts` - Centralized constants including:
   - Extension constants (`CONTROL_PANEL_ROOT_ID`, `SORT_COUNT_ATTR` — the `data-sort-count` attribute driving count-aware CSS breakpoints)
-  - `CSS_CLASSES` - Extension CSS class names (highlight, buttons, labels, `SHOW_NEW`, `NEW_POST`, `CONFLICT_NOTE`, `BUTTONS_TIER`, `DROPDOWN_TIER`, `DROPDOWN_LABEL`, `DROPDOWN`)
+  - `CSS_CLASSES` - Extension CSS class names (highlight, buttons, labels, `SHOW_NEW`, `NEW_POST`, `CONFLICT_NOTE`, `BUTTONS_TIER`, `DROPDOWN_TIER`, `DROPDOWN`)
   - `CSS_SELECTORS` - Derived CSS selectors from class names
   - `SORT_OPTIONS` - Sort option configuration array (sort variant, display text, keyboard shortcut); order: points, time, comments, velocity, heat, default
   - `SETTINGS_KEYS` - Storage key names for chrome.storage.sync (`SHOW_NEW`, `LAST_ACTIVE_SORT`, `POST_IDS_PREFIX`, `COOLDOWN`, `TRUE_TIME_AGO`, `VELOCITY_ENABLED`, `HEAT_ENABLED`)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Sort [Hacker News](https://news.ycombinator.com) your way — by points, time, c
 - **New Post Indicators** — Orange dot marks posts that appeared since your last visit, fading out over a configurable period
 - **True Time Ago** — Corrects misleading ages on resurfaced "second chance" posts
 - **Keyboard Shortcuts** — Press `P`, `T`, `C`, `V`, `H`, or `D` to sort instantly
-- **Responsive Menu** — Full sort names on wide screens, single-letter labels on medium screens, and a compact "Sort by" dropdown on mobile
+- **Responsive Menu** — Full sort names on wide screens, single-letter labels on medium screens, and a compact dropdown on narrow screens — always collapsing before it would crowd Hacker News's own header links
 - **Persistent Preference** — Your last sort choice is remembered across sessions
 - **Visual Highlighting** — Active sort column is highlighted for clarity
 - **Layout Change Detection** — Warning badge and popup banner if HN changes break sorting

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![codecov](https://codecov.io/gh/svyatov/hacker_news_sorted/graph/badge.svg)](https://codecov.io/gh/svyatov/hacker_news_sorted)
 [![License](https://img.shields.io/github/license/svyatov/hacker_news_sorted)](https://github.com/svyatov/hacker_news_sorted/blob/main/LICENSE)
 
-Sort [Hacker News](https://news.ycombinator.com) your way — by points, time, or comments — instantly.
+Sort [Hacker News](https://news.ycombinator.com) your way — by points, time, comments, velocity, or heat — instantly.
 
 <img src="images/demo.gif" width="640" alt="Demo">
 
@@ -22,14 +22,17 @@ Sort [Hacker News](https://news.ycombinator.com) your way — by points, time, o
 - **Sort by Points** — Find the most upvoted stories
 - **Sort by Time** — See the newest posts first
 - **Sort by Comments** — Discover the most discussed topics
+- **Sort by Velocity** — Surface the fastest-rising posts (points per hour, damped so brand-new posts don't dominate) — toggle on/off in the popup
+- **Sort by Heat** — Find where the debate is (comments per point) — toggle on/off in the popup
 - **Restore Default** — Return to HN's original ranking
 - **New Post Indicators** — Orange dot marks posts that appeared since your last visit, fading out over a configurable period
 - **True Time Ago** — Corrects misleading ages on resurfaced "second chance" posts
-- **Keyboard Shortcuts** — Press `P`, `T`, `C`, or `D` to sort instantly
+- **Keyboard Shortcuts** — Press `P`, `T`, `C`, `V`, `H`, or `D` to sort instantly
+- **Responsive Menu** — Full sort names on wide screens, single-letter labels on medium screens, and a compact "Sort by" dropdown on mobile
 - **Persistent Preference** — Your last sort choice is remembered across sessions
 - **Visual Highlighting** — Active sort column is highlighted for clarity
 - **Layout Change Detection** — Warning badge and popup banner if HN changes break sorting
-- **Vimium Compatible** — Shortcuts auto-disable if Vimium or similar extensions are detected
+- **Vimium Compatible** — Shortcuts auto-disable if Vimium or similar extensions are detected, with a note naming the conflicting keys
 - **Dark Mode** — Settings popup follows your system light/dark color scheme
 
 **Compatibility:** Works on any HN page with a post list (front page, Newest, Ask, Show, etc.)

--- a/app/components/ControlPanel.test.tsx
+++ b/app/components/ControlPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import React, { useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -42,8 +42,12 @@ vi.mock('~app/hooks/useSettings', () => ({
 }));
 
 let mockConflictKeys = new Set<string>();
+let capturedKbConfig: { onSort: (sort: SortVariant) => void; enabledSortOptions?: unknown } | undefined;
 vi.mock('~app/hooks/useKeyboardShortcuts', () => ({
-  useKeyboardShortcuts: () => mockConflictKeys,
+  useKeyboardShortcuts: (config: { onSort: (sort: SortVariant) => void; enabledSortOptions?: unknown }) => {
+    capturedKbConfig = config;
+    return mockConflictKeys;
+  },
 }));
 
 vi.mock('~app/utils/sorters', () => ({
@@ -72,6 +76,25 @@ describe('ControlPanel', () => {
     mockEnabledSortOptions = ALL_OPTIONS;
     mockSettled = true;
     mockConflictKeys = new Set();
+    capturedKbConfig = undefined;
+  });
+
+  it('passes the live enabled options through to the keyboard shortcuts hook (AE3 wiring)', () => {
+    const { rerender } = render(<ControlPanel />);
+    expect(capturedKbConfig?.enabledSortOptions).toBe(ALL_OPTIONS);
+
+    mockEnabledSortOptions = NO_DERIVED;
+    rerender(<ControlPanel />);
+    expect(capturedKbConfig?.enabledSortOptions).toBe(NO_DERIVED);
+  });
+
+  it('ignores a sort request for the already-active sort (no-op guard)', () => {
+    render(<ControlPanel />); // active sort starts at 'points'
+    act(() => capturedKbConfig!.onSort('points'));
+    expect(mockIncrementSortCount).not.toHaveBeenCalled();
+
+    act(() => capturedKbConfig!.onSort('time'));
+    expect(mockIncrementSortCount).toHaveBeenCalledOnce();
   });
 
   it('renders a button per enabled option: 6 / 4 / 5', () => {

--- a/app/components/ControlPanel.test.tsx
+++ b/app/components/ControlPanel.test.tsx
@@ -1,12 +1,17 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import React, { useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { CSS_CLASSES } from '~app/constants';
+import { CONTROL_PANEL_ROOT_ID, CSS_CLASSES, SORT_COUNT_ATTR, SORT_OPTIONS } from '~app/constants';
 import type { SortVariant } from '~app/types';
 import { correctAgeTexts, restoreAgeTexts } from '~app/utils/presenters';
 
 import ControlPanel from './ControlPanel';
+
+// Option subsets by enabled count
+const ALL_OPTIONS = SORT_OPTIONS; // 6
+const NO_DERIVED = SORT_OPTIONS.filter((o) => o.sortBy !== 'velocity' && o.sortBy !== 'heat'); // 4
+const VELOCITY_ONLY = SORT_OPTIONS.filter((o) => o.sortBy !== 'heat'); // 5
 
 // Mock the hooks and utilities
 vi.mock('~app/hooks/useParsedRows', () => ({
@@ -20,12 +25,25 @@ vi.mock('~app/utils/presenters', () => ({
 }));
 
 let mockShowTrueTimeAgo = true;
+let mockEnabledSortOptions = ALL_OPTIONS;
+let mockSettled = true;
 
 vi.mock('~app/hooks/useSettings', () => ({
   useSettings: () => {
     const [activeSort, setActiveSort] = useState<SortVariant>('points');
-    return { activeSort, setActiveSort, showTrueTimeAgo: mockShowTrueTimeAgo };
+    return {
+      activeSort,
+      setActiveSort,
+      showTrueTimeAgo: mockShowTrueTimeAgo,
+      enabledSortOptions: mockEnabledSortOptions,
+      settled: mockSettled,
+    };
   },
+}));
+
+let mockConflictKeys = new Set<string>();
+vi.mock('~app/hooks/useKeyboardShortcuts', () => ({
+  useKeyboardShortcuts: () => mockConflictKeys,
 }));
 
 vi.mock('~app/utils/sorters', () => ({
@@ -43,104 +61,146 @@ vi.mock('~app/hooks/useReviewPrompt', () => ({
   }),
 }));
 
+const getButtonsTier = (container: HTMLElement) =>
+  container.querySelector(`.${CSS_CLASSES.BUTTONS_TIER}`) as HTMLElement;
+
 describe('ControlPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    document.body.replaceChildren();
+    mockShowTrueTimeAgo = true;
+    mockEnabledSortOptions = ALL_OPTIONS;
+    mockSettled = true;
+    mockConflictKeys = new Set();
   });
 
-  it('should render all sort buttons', () => {
-    render(<ControlPanel />);
+  it('renders a button per enabled option: 6 / 4 / 5', () => {
+    const { container, rerender } = render(<ControlPanel />);
+    expect(getButtonsTier(container).querySelectorAll(`.${CSS_CLASSES.BTN}`)).toHaveLength(6);
 
-    expect(screen.getByText('points')).toBeInTheDocument();
-    expect(screen.getByText('time')).toBeInTheDocument();
-    expect(screen.getByText('comments')).toBeInTheDocument();
-    expect(screen.getByText('default')).toBeInTheDocument();
+    mockEnabledSortOptions = NO_DERIVED;
+    rerender(<ControlPanel />);
+    expect(getButtonsTier(container).querySelectorAll(`.${CSS_CLASSES.BTN}`)).toHaveLength(4);
+
+    mockEnabledSortOptions = VELOCITY_ONLY;
+    rerender(<ControlPanel />);
+    expect(getButtonsTier(container).querySelectorAll(`.${CSS_CLASSES.BTN}`)).toHaveLength(5);
   });
 
-  it('should render sort by label', () => {
+  it('renders the derived sort buttons and shortcuts when enabled', () => {
+    const { container } = render(<ControlPanel />);
+    const tier = within(getButtonsTier(container));
+
+    expect(tier.getByText('velocity')).toBeInTheDocument();
+    expect(tier.getByText('heat')).toBeInTheDocument();
+    expect(tier.getByText('V')).toBeInTheDocument();
+    expect(tier.getByText('H')).toBeInTheDocument();
+  });
+
+  it('renders the sort by label and divider', () => {
     render(<ControlPanel />);
     expect(screen.getByText('sort by:')).toBeInTheDocument();
-  });
-
-  it('should render divider', () => {
-    render(<ControlPanel />);
     expect(screen.getByText('|')).toBeInTheDocument();
   });
 
-  it('should render shortcuts for all buttons', () => {
-    render(<ControlPanel />);
-
-    expect(screen.getByText('P')).toBeInTheDocument();
-    expect(screen.getByText('T')).toBeInTheDocument();
-    expect(screen.getByText('C')).toBeInTheDocument();
-    expect(screen.getByText('D')).toBeInTheDocument();
-  });
-
-  it('should switch active sort when clicking buttons', () => {
-    render(<ControlPanel />);
-
-    // Initially points should be active (mocked getLastActiveSort returns 'points')
-    const pointsButton = screen.getByText('points').closest(`.${CSS_CLASSES.BTN}`);
-    expect(pointsButton?.classList.contains(CSS_CLASSES.ACTIVE)).toBe(true);
-
-    // Click time button
-    fireEvent.click(screen.getByText('time'));
-
-    // Time button should now be active
-    const timeButton = screen.getByText('time').closest(`.${CSS_CLASSES.BTN}`);
-    expect(timeButton?.classList.contains(CSS_CLASSES.ACTIVE)).toBe(true);
-
-    // Points button should no longer be active
-    const updatedPointsButton = screen.getByText('points').closest(`.${CSS_CLASSES.BTN}`);
-    expect(updatedPointsButton?.classList.contains(CSS_CLASSES.ACTIVE)).toBe(false);
-  });
-
-  it('should render separators between buttons', () => {
+  it('renders a separator between each enabled button', () => {
     const { container } = render(<ControlPanel />);
-
-    // Check that separators are rendered between buttons (3 separators for 4 buttons)
-    const text = container.textContent;
-    const separatorCount = (text?.match(/·/g) || []).length;
-    expect(separatorCount).toBe(3);
+    const separatorCount = (getButtonsTier(container).textContent?.match(/·/g) || []).length;
+    expect(separatorCount).toBe(5); // 6 options → 5 separators
   });
 
-  it('should call incrementSortCount when switching sort', () => {
-    render(<ControlPanel />);
+  it('renders nothing until the settled flag flips', () => {
+    mockSettled = false;
+    const { container } = render(<ControlPanel />);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('sort by:')).not.toBeInTheDocument();
+  });
 
-    fireEvent.click(screen.getByText('time'));
+  it('publishes the enabled-option count on the panel root and updates it on toggle change', () => {
+    const root = document.createElement('span');
+    root.id = CONTROL_PANEL_ROOT_ID;
+    document.body.appendChild(root);
+
+    const { rerender } = render(<ControlPanel />);
+    expect(root.getAttribute(SORT_COUNT_ATTR)).toBe('6');
+
+    mockEnabledSortOptions = NO_DERIVED;
+    rerender(<ControlPanel />);
+    expect(root.getAttribute(SORT_COUNT_ATTR)).toBe('4');
+  });
+
+  it('switches active sort and marks the clicked derived button active', () => {
+    const { container } = render(<ControlPanel />);
+    fireEvent.click(container.querySelector('button[data-sort="velocity"]')!);
+
+    expect(container.querySelector('button[data-sort="velocity"]')!.classList.contains(CSS_CLASSES.ACTIVE)).toBe(true);
+    expect(container.querySelector('button[data-sort="points"]')!.classList.contains(CSS_CLASSES.ACTIVE)).toBe(false);
     expect(mockIncrementSortCount).toHaveBeenCalledOnce();
   });
 
-  it('should not call incrementSortCount when clicking active sort', () => {
-    render(<ControlPanel />);
+  describe('conflict note (AE4 render half)', () => {
+    it('renders no note when the conflict set is empty', () => {
+      const { container } = render(<ControlPanel />);
+      expect(container.querySelector(`.${CSS_CLASSES.CONFLICT_NOTE}`)).toBeNull();
+    });
 
-    fireEvent.click(screen.getByText('points'));
-    expect(mockIncrementSortCount).not.toHaveBeenCalled();
+    it('renders a note listing each conflicting key as a polite live region', () => {
+      mockConflictKeys = new Set(['t', 'c']);
+      const { container } = render(<ControlPanel />);
+
+      const note = container.querySelector(`.${CSS_CLASSES.CONFLICT_NOTE}`)!;
+      expect(note).not.toBeNull();
+      expect(note.getAttribute('role')).toBe('status');
+      expect(note.textContent).toContain('T, C');
+    });
   });
 
-  it('should render review toast when showPrompt is true', () => {
-    render(<ControlPanel />);
+  describe('mobile dropdown tier', () => {
+    it('renders one option per enabled sort with the active one selected', () => {
+      const select = renderSelect();
+      const options = within(select).getAllByRole('option');
+      expect(options).toHaveLength(6);
+      expect(select.value).toBe('points');
+    });
 
+    it('does not include a disabled sort in the dropdown', () => {
+      mockEnabledSortOptions = NO_DERIVED;
+      const select = renderSelect();
+      const values = within(select)
+        .getAllByRole('option')
+        .map((o) => (o as HTMLOptionElement).value);
+      expect(values).not.toContain('velocity');
+      expect(values).not.toContain('heat');
+    });
+
+    it('changing the dropdown triggers the same sort path as the buttons', () => {
+      const select = renderSelect();
+      fireEvent.change(select, { target: { value: 'heat' } });
+      expect(select.value).toBe('heat');
+      expect(mockIncrementSortCount).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('renders review toast and dismisses it', () => {
+    render(<ControlPanel />);
     expect(screen.getByText(/Leave a review/)).toBeInTheDocument();
-    expect(screen.getByLabelText('Dismiss')).toBeInTheDocument();
-  });
-
-  it('should call dismissPrompt when clicking dismiss button', () => {
-    render(<ControlPanel />);
-
     fireEvent.click(screen.getByLabelText('Dismiss'));
     expect(mockDismissPrompt).toHaveBeenCalledOnce();
   });
 
-  it('should call restoreAgeTexts when showTrueTimeAgo is false', () => {
+  it('calls restoreAgeTexts when showTrueTimeAgo is false', () => {
     mockShowTrueTimeAgo = false;
     render(<ControlPanel />);
     expect(restoreAgeTexts).toHaveBeenCalled();
-    mockShowTrueTimeAgo = true;
   });
 
-  it('should call correctAgeTexts when showTrueTimeAgo is true', () => {
+  it('calls correctAgeTexts when showTrueTimeAgo is true', () => {
     render(<ControlPanel />);
     expect(correctAgeTexts).toHaveBeenCalled();
   });
 });
+
+const renderSelect = (): HTMLSelectElement => {
+  render(<ControlPanel />);
+  return screen.getByRole('combobox') as HTMLSelectElement;
+};

--- a/app/components/ControlPanel.test.tsx
+++ b/app/components/ControlPanel.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CONTROL_PANEL_ROOT_ID, CSS_CLASSES, SORT_COUNT_ATTR, SORT_OPTIONS } from '~app/constants';
 import type { SortVariant } from '~app/types';
-import { correctAgeTexts, restoreAgeTexts } from '~app/utils/presenters';
+import { correctAgeTexts, restoreAgeTexts, updateTable } from '~app/utils/presenters';
 
 import ControlPanel from './ControlPanel';
 
@@ -138,6 +138,11 @@ describe('ControlPanel', () => {
     const { container } = render(<ControlPanel />);
     expect(container).toBeEmptyDOMElement();
     expect(screen.queryByText('sort by:')).not.toBeInTheDocument();
+    // The table-update effect must also bail on the settled gate, not just the render, so rows
+    // aren't reordered against unresolved settings (KTD-8).
+    expect(updateTable).not.toHaveBeenCalled();
+    expect(correctAgeTexts).not.toHaveBeenCalled();
+    expect(restoreAgeTexts).not.toHaveBeenCalled();
   });
 
   it('publishes the enabled-option count on the panel root and updates it on toggle change', () => {

--- a/app/components/ControlPanel.test.tsx
+++ b/app/components/ControlPanel.test.tsx
@@ -121,9 +121,10 @@ describe('ControlPanel', () => {
   });
 
   it('renders the sort by label and divider', () => {
-    render(<ControlPanel />);
-    expect(screen.getByText('sort by:')).toBeInTheDocument();
-    expect(screen.getByText('|')).toBeInTheDocument();
+    const { container } = render(<ControlPanel />);
+    const tier = within(getButtonsTier(container));
+    expect(tier.getByText('sort by:')).toBeInTheDocument();
+    expect(tier.getByText('|')).toBeInTheDocument();
   });
 
   it('renders a separator between each enabled button', () => {
@@ -201,6 +202,12 @@ describe('ControlPanel', () => {
       fireEvent.change(select, { target: { value: 'heat' } });
       expect(select.value).toBe('heat');
       expect(mockIncrementSortCount).toHaveBeenCalledOnce();
+    });
+
+    it('renders a divider after the select so it reads separately from HN header links', () => {
+      const { container } = render(<ControlPanel />);
+      const tier = container.querySelector(`.${CSS_CLASSES.DROPDOWN_TIER}`) as HTMLElement;
+      expect(within(tier).getByText('|')).toBeInTheDocument();
     });
   });
 

--- a/app/components/ControlPanel.tsx
+++ b/app/components/ControlPanel.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useCallback, useEffect, useMemo, type ReactElement } from 'react';
 
 import SortButton from '~app/components/SortButton';
-import { CSS_CLASSES, CWS_REVIEW_URL, SORT_OPTIONS } from '~app/constants';
+import { CONTROL_PANEL_ROOT_ID, CSS_CLASSES, CWS_REVIEW_URL, SORT_COUNT_ATTR } from '~app/constants';
 import { useKeyboardShortcuts } from '~app/hooks/useKeyboardShortcuts';
 import { useParsedRows } from '~app/hooks/useParsedRows';
 import { useReviewPrompt } from '~app/hooks/useReviewPrompt';
@@ -10,10 +10,8 @@ import type { SortVariant } from '~app/types';
 import { correctAgeTexts, restoreAgeTexts, updateTable } from '~app/utils/presenters';
 import { sortRows } from '~app/utils/sorters';
 
-const sortOptionsCount = SORT_OPTIONS.length - 1;
-
-const ControlPanel = (): ReactElement => {
-  const { activeSort, setActiveSort, showTrueTimeAgo } = useSettings();
+const ControlPanel = (): ReactElement | null => {
+  const { activeSort, setActiveSort, showTrueTimeAgo, enabledSortOptions, settled } = useSettings();
   const { parsedRows, footerRows } = useParsedRows();
   const { showPrompt, dismissPrompt, incrementSortCount } = useReviewPrompt();
 
@@ -28,6 +26,12 @@ const ControlPanel = (): ReactElement => {
     }
   }, [sortedRows, footerRows, activeSort, showTrueTimeAgo]);
 
+  // Publish the enabled-option count on the imperatively-created panel root (outside
+  // React's tree) so count-aware CSS breakpoints can key off it (KTD-3).
+  useEffect(() => {
+    document.getElementById(CONTROL_PANEL_ROOT_ID)?.setAttribute(SORT_COUNT_ATTR, String(enabledSortOptions.length));
+  }, [enabledSortOptions.length]);
+
   const handleSort = useCallback(
     (sortBy: SortVariant) => {
       if (sortBy === activeSort) return;
@@ -37,32 +41,61 @@ const ControlPanel = (): ReactElement => {
     [activeSort, setActiveSort, incrementSortCount],
   );
 
-  useKeyboardShortcuts({ onSort: handleSort });
+  const conflictKeys = useKeyboardShortcuts({ onSort: handleSort, enabledSortOptions });
+
+  // Wait for the settled settings read before painting so the panel doesn't flash a
+  // six-option layout that reflows to four/five for users who disabled a sort (KTD-8).
+  if (!settled) return null;
+
+  const lastIndex = enabledSortOptions.length - 1;
 
   return (
     <>
-      <span className={CSS_CLASSES.SORT_BY_LABEL}>sort by:</span>
+      <span className={CSS_CLASSES.BUTTONS_TIER}>
+        <span className={CSS_CLASSES.SORT_BY_LABEL}>sort by:</span>
 
-      {SORT_OPTIONS.map((option, index) => (
-        <Fragment key={option.sortBy}>
-          <SortButton sortOption={option} activeSort={activeSort} setActiveSort={handleSort} />
-          {index < sortOptionsCount && ' · '}
-        </Fragment>
-      ))}
+        {enabledSortOptions.map((option, index) => (
+          <Fragment key={option.sortBy}>
+            <SortButton sortOption={option} activeSort={activeSort} setActiveSort={handleSort} />
+            {index < lastIndex && ' · '}
+          </Fragment>
+        ))}
 
-      <span className={CSS_CLASSES.DIVIDER}>|</span>
+        <span className={CSS_CLASSES.DIVIDER}>|</span>
 
-      {showPrompt && (
-        <span className={CSS_CLASSES.REVIEW_TOAST}>
-          <a href={CWS_REVIEW_URL} target="_blank" rel="noopener" className={CSS_CLASSES.REVIEW_LINK}>
-            <span>{'Enjoying HN Sorted? Leave a review \u2764\ufe0f'}</span>
-            <span className={CSS_CLASSES.REVIEW_SUB}>Support the extension, help others discover it</span>
-          </a>
-          <button type="button" className={CSS_CLASSES.REVIEW_CLOSE} onClick={dismissPrompt} aria-label="Dismiss">
-            {'\u00d7'}
-          </button>
-        </span>
-      )}
+        {conflictKeys.size > 0 && (
+          <span className={CSS_CLASSES.CONFLICT_NOTE} role="status">
+            {`hotkeys off: ${[...conflictKeys].map((key) => key.toUpperCase()).join(', ')} taken by another extension`}
+          </span>
+        )}
+
+        {showPrompt && (
+          <span className={CSS_CLASSES.REVIEW_TOAST}>
+            <a href={CWS_REVIEW_URL} target="_blank" rel="noopener" className={CSS_CLASSES.REVIEW_LINK}>
+              <span>{'Enjoying HN Sorted? Leave a review \u2764\ufe0f'}</span>
+              <span className={CSS_CLASSES.REVIEW_SUB}>Support the extension, help others discover it</span>
+            </a>
+            <button type="button" className={CSS_CLASSES.REVIEW_CLOSE} onClick={dismissPrompt} aria-label="Dismiss">
+              {'\u00d7'}
+            </button>
+          </span>
+        )}
+      </span>
+
+      <span className={CSS_CLASSES.DROPDOWN_TIER}>
+        <span className={CSS_CLASSES.DROPDOWN_LABEL}>Sort by</span>
+        <select
+          className={CSS_CLASSES.DROPDOWN}
+          aria-label="Sort by"
+          value={activeSort}
+          onChange={(event) => handleSort(event.target.value as SortVariant)}>
+          {enabledSortOptions.map((option) => (
+            <option key={option.sortBy} value={option.sortBy}>
+              {option.text}
+            </option>
+          ))}
+        </select>
+      </span>
     </>
   );
 };

--- a/app/components/ControlPanel.tsx
+++ b/app/components/ControlPanel.tsx
@@ -10,6 +10,9 @@ import type { SortVariant } from '~app/types';
 import { correctAgeTexts, restoreAgeTexts, updateTable } from '~app/utils/presenters';
 import { sortRows } from '~app/utils/sorters';
 
+// Shared so the dropdown's visible label and its aria-label can't drift apart.
+const SORT_BY_TEXT = 'Sort by';
+
 const ControlPanel = (): ReactElement | null => {
   const { activeSort, setActiveSort, showTrueTimeAgo, enabledSortOptions, settled } = useSettings();
   const { parsedRows, footerRows } = useParsedRows();
@@ -18,13 +21,16 @@ const ControlPanel = (): ReactElement | null => {
   const sortedRows = useMemo(() => sortRows(parsedRows, activeSort), [parsedRows, activeSort]);
 
   useEffect(() => {
+    // Wait for the settled read so the table sorts once with the resolved sort, instead of
+    // reordering from the default first and then again once settings load (PE2).
+    if (!settled) return;
     updateTable(sortedRows, footerRows, activeSort);
     if (showTrueTimeAgo) {
       correctAgeTexts(sortedRows);
     } else {
       restoreAgeTexts(sortedRows);
     }
-  }, [sortedRows, footerRows, activeSort, showTrueTimeAgo]);
+  }, [sortedRows, footerRows, activeSort, showTrueTimeAgo, settled]);
 
   // Publish the enabled-option count on the imperatively-created panel root (outside
   // React's tree) so count-aware CSS breakpoints can key off it (KTD-3).
@@ -83,10 +89,10 @@ const ControlPanel = (): ReactElement | null => {
       </span>
 
       <span className={CSS_CLASSES.DROPDOWN_TIER}>
-        <span className={CSS_CLASSES.DROPDOWN_LABEL}>Sort by</span>
+        <span className={CSS_CLASSES.DROPDOWN_LABEL}>{SORT_BY_TEXT}</span>
         <select
           className={CSS_CLASSES.DROPDOWN}
-          aria-label="Sort by"
+          aria-label={SORT_BY_TEXT}
           value={activeSort}
           onChange={(event) => handleSort(event.target.value as SortVariant)}>
           {enabledSortOptions.map((option) => (

--- a/app/components/ControlPanel.tsx
+++ b/app/components/ControlPanel.tsx
@@ -48,7 +48,12 @@ const ControlPanel = (): ReactElement | null => {
     [activeSort, setActiveSort, incrementSortCount],
   );
 
-  const conflictKeys = useKeyboardShortcuts({ onSort: handleSort, enabledSortOptions });
+  // Keep the keydown listener inert until the panel is settled/visible: before then the option
+  // list is still the default-on set, so an early V/H press would sort an invisible panel.
+  const conflictKeys = useKeyboardShortcuts({
+    onSort: handleSort,
+    enabledSortOptions: settled ? enabledSortOptions : [],
+  });
 
   // Wait for the settled settings read before painting so the panel doesn't flash a
   // six-option layout that reflows to four/five for users who disabled a sort (KTD-8).
@@ -69,12 +74,6 @@ const ControlPanel = (): ReactElement | null => {
         ))}
 
         <span className={CSS_CLASSES.DIVIDER}>|</span>
-
-        {conflictKeys.size > 0 && (
-          <span className={CSS_CLASSES.CONFLICT_NOTE} role="status">
-            {`hotkeys off: ${[...conflictKeys].map((key) => key.toUpperCase()).join(', ')} taken by another extension`}
-          </span>
-        )}
 
         {showPrompt && (
           <span className={CSS_CLASSES.REVIEW_TOAST}>
@@ -103,6 +102,14 @@ const ControlPanel = (): ReactElement | null => {
         </select>
         <span className={CSS_CLASSES.DIVIDER}>|</span>
       </span>
+
+      {/* Top-level (outside both tiers) so a responsive tier's display:none can't hide it — the
+          note explains why hotkeys stopped working and must survive on narrow screens too. */}
+      {conflictKeys.size > 0 && (
+        <span className={CSS_CLASSES.CONFLICT_NOTE} role="status">
+          {`hotkeys off: ${[...conflictKeys].map((key) => key.toUpperCase()).join(', ')} taken by another extension`}
+        </span>
+      )}
     </>
   );
 };

--- a/app/components/ControlPanel.tsx
+++ b/app/components/ControlPanel.tsx
@@ -10,7 +10,8 @@ import type { SortVariant } from '~app/types';
 import { correctAgeTexts, restoreAgeTexts, updateTable } from '~app/utils/presenters';
 import { sortRows } from '~app/utils/sorters';
 
-// Shared so the dropdown's visible label and its aria-label can't drift apart.
+// Accessible name for the mobile sort <select> (it has no visible label — a visible one is wide
+// enough to push HN's own nav onto a second line on narrow screens).
 const SORT_BY_TEXT = 'Sort by';
 
 const ControlPanel = (): ReactElement | null => {
@@ -89,7 +90,6 @@ const ControlPanel = (): ReactElement | null => {
       </span>
 
       <span className={CSS_CLASSES.DROPDOWN_TIER}>
-        <span className={CSS_CLASSES.DROPDOWN_LABEL}>{SORT_BY_TEXT}</span>
         <select
           className={CSS_CLASSES.DROPDOWN}
           aria-label={SORT_BY_TEXT}
@@ -101,6 +101,7 @@ const ControlPanel = (): ReactElement | null => {
             </option>
           ))}
         </select>
+        <span className={CSS_CLASSES.DIVIDER}>|</span>
       </span>
     </>
   );

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -2,6 +2,9 @@ import type { SortOption } from '~app/types';
 
 // Extension constants
 export const CONTROL_PANEL_ROOT_ID = 'hns-control-panel';
+// Enabled-option count (4–6) published on the panel root so count-aware CSS breakpoints
+// can pick the right word↔letter switch point (CSS can't read React state).
+export const SORT_COUNT_ATTR = 'data-sort-count';
 
 // Settings keys and defaults (chrome.storage.sync)
 export const SETTINGS_KEYS = {
@@ -14,6 +17,8 @@ export const SETTINGS_KEYS = {
   SORT_COUNT: 'hns-sort-count',
   COOLDOWN: 'hns-cooldown',
   TRUE_TIME_AGO: 'hns-true-time-ago',
+  VELOCITY_ENABLED: 'hns-velocity-enabled',
+  HEAT_ENABLED: 'hns-heat-enabled',
 } as const;
 
 export const SETTINGS_DEFAULTS = {
@@ -25,6 +30,8 @@ export const SETTINGS_DEFAULTS = {
   [SETTINGS_KEYS.SORT_COUNT]: 0 as number,
   [SETTINGS_KEYS.COOLDOWN]: 3600 as number,
   [SETTINGS_KEYS.TRUE_TIME_AGO]: true as boolean,
+  [SETTINGS_KEYS.VELOCITY_ENABLED]: true as boolean,
+  [SETTINGS_KEYS.HEAT_ENABLED]: true as boolean,
 } as const;
 
 // Time conversions
@@ -56,6 +63,11 @@ export const CSS_CLASSES = {
   DIVIDER: 'hns-divider',
   SHOW_NEW: 'hns-show-new',
   NEW_POST: 'hns-new-post',
+  CONFLICT_NOTE: 'hns-conflict-note',
+  BUTTONS_TIER: 'hns-buttons-tier',
+  DROPDOWN_TIER: 'hns-dropdown-tier',
+  DROPDOWN_LABEL: 'hns-dropdown-label',
+  DROPDOWN: 'hns-dropdown',
   REVIEW_TOAST: 'hns-review-toast',
   REVIEW_LINK: 'hns-review-link',
   REVIEW_SUB: 'hns-review-sub',
@@ -71,6 +83,8 @@ export const SORT_OPTIONS: SortOption[] = [
   { sortBy: 'points', text: 'points', shortcut: 'P' },
   { sortBy: 'time', text: 'time', shortcut: 'T' },
   { sortBy: 'comments', text: 'comments', shortcut: 'C' },
+  { sortBy: 'velocity', text: 'velocity', shortcut: 'V' },
+  { sortBy: 'heat', text: 'heat', shortcut: 'H' },
   { sortBy: 'default', text: 'default', shortcut: 'D' },
 ];
 

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -66,7 +66,6 @@ export const CSS_CLASSES = {
   CONFLICT_NOTE: 'hns-conflict-note',
   BUTTONS_TIER: 'hns-buttons-tier',
   DROPDOWN_TIER: 'hns-dropdown-tier',
-  DROPDOWN_LABEL: 'hns-dropdown-label',
   DROPDOWN: 'hns-dropdown',
   REVIEW_TOAST: 'hns-review-toast',
   REVIEW_LINK: 'hns-review-link',
@@ -80,9 +79,10 @@ export const CSS_SELECTORS = {
 
 // Sort options configuration. Order matters — the menu and dropdown render in this order.
 // Two couplings to keep in sync when editing this list:
-//   1. content.css has one word<->letter @media block per possible enabled-option count
-//      (data-sort-count). Adding an option — or another disable toggle — changes that range and
-//      needs a matching block, or the panel silently stays in single-letter mode at all widths.
+//   1. content.css has count-aware @media blocks keyed on data-sort-count — one word<->letter block
+//      AND one letter<->dropdown block per possible enabled-option count (4/5/6). Adding an option —
+//      or another disable toggle — changes those widths and needs matching blocks, or the panel
+//      stays in single-letter mode at all widths / collapses at the wrong width and wraps HN's nav.
 //   2. useKeyboardShortcuts derives its hotkeys from `shortcut` below — keep the letters unique.
 export const SORT_OPTIONS: SortOption[] = [
   { sortBy: 'points', text: 'points', shortcut: 'P' },

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -78,7 +78,12 @@ export const CSS_SELECTORS = {
   HIGHLIGHT: `.${CSS_CLASSES.HIGHLIGHT}`,
 } as const;
 
-// Sort options configuration
+// Sort options configuration. Order matters — the menu and dropdown render in this order.
+// Two couplings to keep in sync when editing this list:
+//   1. content.css has one word<->letter @media block per possible enabled-option count
+//      (data-sort-count). Adding an option — or another disable toggle — changes that range and
+//      needs a matching block, or the panel silently stays in single-letter mode at all widths.
+//   2. useKeyboardShortcuts derives its hotkeys from `shortcut` below — keep the letters unique.
 export const SORT_OPTIONS: SortOption[] = [
   { sortBy: 'points', text: 'points', shortcut: 'P' },
   { sortBy: 'time', text: 'time', shortcut: 'T' },

--- a/app/content-css-breakpoints.test.ts
+++ b/app/content-css-breakpoints.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { SORT_OPTIONS } from '~app/constants';
+
+// Sorts that have a disable toggle (mirror enabledSortSet in app/hooks/useSettings.ts). Every
+// other sort is always on, so enabledSortOptions.length ranges over
+// [SORT_OPTIONS.length - toggles, SORT_OPTIONS.length]. content.css must carry one word<->letter
+// AND one letter<->dropdown @media block per reachable count, or the responsive menu silently
+// stops collapsing at some option count and pushes HN's own header nav onto a second line.
+const TOGGLEABLE_SORTS = ['velocity', 'heat'];
+
+const css = readFileSync(join(__dirname, '..', 'content.css'), 'utf8');
+
+describe('content.css count-aware breakpoints', () => {
+  const maxCount = SORT_OPTIONS.length;
+  const minCount = SORT_OPTIONS.length - TOGGLEABLE_SORTS.length;
+  const counts = Array.from({ length: maxCount - minCount + 1 }, (_, i) => minCount + i);
+
+  it('keeps TOGGLEABLE_SORTS in sync with SORT_OPTIONS', () => {
+    const known = new Set(SORT_OPTIONS.map((option) => option.sortBy));
+    for (const sort of TOGGLEABLE_SORTS) {
+      expect(known.has(sort as (typeof SORT_OPTIONS)[number]['sortBy'])).toBe(true);
+    }
+  });
+
+  it.each(counts)("has a word<->letter block for data-sort-count='%i'", (n) => {
+    expect(css).toMatch(new RegExp(`#hns-control-panel\\[data-sort-count='${n}'\\]\\s+\\.hns-btn-text`));
+  });
+
+  it.each(counts)("has a letter<->dropdown block for data-sort-count='%i'", (n) => {
+    expect(css).toMatch(new RegExp(`#hns-control-panel\\[data-sort-count='${n}'\\]\\s+\\.hns-buttons-tier`));
+  });
+});

--- a/app/hooks/useKeyboardShortcuts.test.ts
+++ b/app/hooks/useKeyboardShortcuts.test.ts
@@ -1,7 +1,11 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { SORT_OPTIONS } from '~app/constants';
+
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
+
+const withoutSort = (sortBy: string) => SORT_OPTIONS.filter((o) => o.sortBy !== sortBy);
 
 describe('useKeyboardShortcuts', () => {
   const mockOnSort = vi.fn();
@@ -60,6 +64,20 @@ describe('useKeyboardShortcuts', () => {
 
     simulateKeyPress('d');
     expect(mockOnSort).toHaveBeenCalledWith('default');
+  });
+
+  it('should call onSort with "velocity" when V is pressed', () => {
+    renderHook(() => useKeyboardShortcuts({ onSort: mockOnSort }));
+
+    simulateKeyPress('v');
+    expect(mockOnSort).toHaveBeenCalledWith('velocity');
+  });
+
+  it('should call onSort with "heat" when H is pressed', () => {
+    renderHook(() => useKeyboardShortcuts({ onSort: mockOnSort }));
+
+    simulateKeyPress('h');
+    expect(mockOnSort).toHaveBeenCalledWith('heat');
   });
 
   it('should handle uppercase keys', () => {
@@ -191,6 +209,68 @@ describe('useKeyboardShortcuts', () => {
       mockOnSort.mockClear();
 
       // Second press of same key - should still work (not re-checking)
+      simulateKeyPress('p');
+      expect(mockOnSort).toHaveBeenCalledWith('points');
+    });
+
+    it('lands an intercepted key in the returned conflict set and stops all shortcuts (AE4)', () => {
+      const { result } = renderHook(() => useKeyboardShortcuts({ onSort: mockOnSort }));
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 't', bubbles: true });
+        Object.defineProperty(event, 'defaultPrevented', { value: true });
+        document.dispatchEvent(event);
+      });
+
+      expect(result.current.has('t')).toBe(true);
+
+      simulateKeyPress('p');
+      simulateKeyPress('c');
+      expect(mockOnSort).not.toHaveBeenCalled();
+    });
+
+    it('accumulates multiple intercepted keys in the conflict set', () => {
+      const { result } = renderHook(() => useKeyboardShortcuts({ onSort: mockOnSort }));
+
+      act(() => {
+        const tEvent = new KeyboardEvent('keydown', { key: 't', bubbles: true });
+        Object.defineProperty(tEvent, 'defaultPrevented', { value: true });
+        document.dispatchEvent(tEvent);
+        const cEvent = new KeyboardEvent('keydown', { key: 'c', bubbles: true });
+        Object.defineProperty(cEvent, 'defaultPrevented', { value: true });
+        document.dispatchEvent(cEvent);
+      });
+
+      expect(result.current.has('t')).toBe(true);
+      expect(result.current.has('c')).toBe(true);
+    });
+  });
+
+  describe('enabled gating', () => {
+    it('does nothing when a disabled sort key is pressed (AE3 hotkey half)', () => {
+      renderHook(() => useKeyboardShortcuts({ onSort: mockOnSort, enabledSortOptions: withoutSort('velocity') }));
+
+      simulateKeyPress('v');
+      expect(mockOnSort).not.toHaveBeenCalled();
+
+      // The other derived key still works
+      simulateKeyPress('h');
+      expect(mockOnSort).toHaveBeenCalledWith('heat');
+    });
+
+    it('does not flag a conflict for a disabled key', () => {
+      const { result } = renderHook(() =>
+        useKeyboardShortcuts({ onSort: mockOnSort, enabledSortOptions: withoutSort('velocity') }),
+      );
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'v', bubbles: true });
+        Object.defineProperty(event, 'defaultPrevented', { value: true });
+        document.dispatchEvent(event);
+      });
+
+      expect(result.current.size).toBe(0);
+      // Enabled shortcuts keep working
       simulateKeyPress('p');
       expect(mockOnSort).toHaveBeenCalledWith('points');
     });

--- a/app/hooks/useKeyboardShortcuts.test.ts
+++ b/app/hooks/useKeyboardShortcuts.test.ts
@@ -213,6 +213,27 @@ describe('useKeyboardShortcuts', () => {
       expect(mockOnSort).toHaveBeenCalledWith('points');
     });
 
+    it('bails on a later intercepted press of an already-checked key without recording a conflict', () => {
+      const { result } = renderHook(() => useKeyboardShortcuts({ onSort: mockOnSort }));
+
+      // First press, not intercepted: sorts and records the key as checked (no conflict yet).
+      simulateKeyPress('p');
+      expect(mockOnSort).toHaveBeenCalledWith('points');
+      expect(result.current.size).toBe(0);
+      mockOnSort.mockClear();
+
+      // Same key intercepted on a LATER press: the check-once block is skipped, but the
+      // defaultPrevented bail still stops the sort — and the key is not added to the conflict set.
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'p', bubbles: true });
+        Object.defineProperty(event, 'defaultPrevented', { value: true });
+        document.dispatchEvent(event);
+      });
+
+      expect(mockOnSort).not.toHaveBeenCalled();
+      expect(result.current.size).toBe(0);
+    });
+
     it('lands an intercepted key in the returned conflict set and stops all shortcuts (AE4)', () => {
       const { result } = renderHook(() => useKeyboardShortcuts({ onSort: mockOnSort }));
 

--- a/app/hooks/useKeyboardShortcuts.test.ts
+++ b/app/hooks/useKeyboardShortcuts.test.ts
@@ -274,5 +274,29 @@ describe('useKeyboardShortcuts', () => {
       simulateKeyPress('p');
       expect(mockOnSort).toHaveBeenCalledWith('points');
     });
+
+    it('drops a conflicting key from the note once its sort is disabled, re-enabling the rest (R11)', () => {
+      const { result, rerender } = renderHook(
+        ({ opts }) => useKeyboardShortcuts({ onSort: mockOnSort, enabledSortOptions: opts }),
+        { initialProps: { opts: SORT_OPTIONS } },
+      );
+
+      // Another extension intercepts V → recorded, and all-or-nothing disables every shortcut
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'v', bubbles: true });
+        Object.defineProperty(event, 'defaultPrevented', { value: true });
+        document.dispatchEvent(event);
+      });
+      expect(result.current.has('v')).toBe(true);
+      simulateKeyPress('p');
+      expect(mockOnSort).not.toHaveBeenCalled();
+
+      // User disables Velocity: V is no longer our shortcut, so it leaves the conflict set
+      // and the remaining hotkeys come back.
+      rerender({ opts: withoutSort('velocity') });
+      expect(result.current.has('v')).toBe(false);
+      simulateKeyPress('p');
+      expect(mockOnSort).toHaveBeenCalledWith('points');
+    });
   });
 });

--- a/app/hooks/useKeyboardShortcuts.ts
+++ b/app/hooks/useKeyboardShortcuts.ts
@@ -8,17 +8,12 @@ type KeyboardShortcutsConfig = {
   enabledSortOptions?: SortOption[];
 };
 
-const TARGET_KEYS = ['p', 't', 'c', 'v', 'h', 'd'] as const;
-type TargetKey = (typeof TARGET_KEYS)[number];
-
-const KEY_TO_SORT: Record<TargetKey, SortVariant> = {
-  p: 'points',
-  t: 'time',
-  c: 'comments',
-  v: 'velocity',
-  h: 'heat',
-  d: 'default',
-};
+// Hotkeys derive from SORT_OPTIONS so a shortcut change there can't silently diverge from the
+// handler (single source of truth). Letters are lower-cased for case-insensitive matching.
+const KEY_TO_SORT: Record<string, SortVariant> = Object.fromEntries(
+  SORT_OPTIONS.map((option) => [option.shortcut.toLowerCase(), option.sortBy]),
+);
+const TARGET_KEYS = Object.keys(KEY_TO_SORT);
 
 const isTypingInInput = (target: EventTarget | null): boolean => {
   if (!target || !(target instanceof HTMLElement)) {
@@ -50,6 +45,19 @@ export const useKeyboardShortcuts = ({
     return new Set<string>(TARGET_KEYS.filter((key) => enabled.has(KEY_TO_SORT[key])));
   }, [enabledSortOptions]);
 
+  // Reconcile recorded conflicts with the live key set: when a sort is disabled its key is no
+  // longer our shortcut, so drop it from the note (R11) and stop it gating the rest; prune
+  // checkedKeys too so a key that is later re-enabled gets conflict-checked afresh.
+  useEffect(() => {
+    const keep = (set: Set<string>) => new Set([...set].filter((key) => activeKeys.has(key)));
+    checkedKeys.current = keep(checkedKeys.current);
+    const prunedConflicts = keep(conflictKeysRef.current);
+    if (prunedConflicts.size !== conflictKeysRef.current.size) {
+      conflictKeysRef.current = prunedConflicts;
+      setConflictKeys(prunedConflicts);
+    }
+  }, [activeKeys]);
+
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       const key = event.key.toLowerCase();
@@ -79,13 +87,16 @@ export const useKeyboardShortcuts = ({
         }
       }
 
+      // Bail if any prior conflict was recorded (all-or-nothing), or if THIS press is being
+      // prevented by another extension — the latter also covers a key intercepted only on a
+      // later press, which the check-once block above skips.
       if (conflictKeysRef.current.size > 0 || event.defaultPrevented) {
         return;
       }
 
       // Handle the sort
       event.preventDefault();
-      onSort(KEY_TO_SORT[key as TargetKey]);
+      onSort(KEY_TO_SORT[key]);
     },
     [onSort, activeKeys],
   );

--- a/app/hooks/useKeyboardShortcuts.ts
+++ b/app/hooks/useKeyboardShortcuts.ts
@@ -1,17 +1,22 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import type { SortVariant } from '~app/types';
+import { SORT_OPTIONS } from '~app/constants';
+import type { SortOption, SortVariant } from '~app/types';
 
 type KeyboardShortcutsConfig = {
   onSort: (sortBy: SortVariant) => void;
+  enabledSortOptions?: SortOption[];
 };
 
-const TARGET_KEYS = ['p', 't', 'c', 'd'] as const;
+const TARGET_KEYS = ['p', 't', 'c', 'v', 'h', 'd'] as const;
+type TargetKey = (typeof TARGET_KEYS)[number];
 
-const KEY_TO_SORT: Record<(typeof TARGET_KEYS)[number], SortVariant> = {
+const KEY_TO_SORT: Record<TargetKey, SortVariant> = {
   p: 'points',
   t: 'time',
   c: 'comments',
+  v: 'velocity',
+  h: 'heat',
   d: 'default',
 };
 
@@ -30,16 +35,27 @@ const isTypingInInput = (target: EventTarget | null): boolean => {
   return target.isContentEditable || target.contentEditable === 'true';
 };
 
-export const useKeyboardShortcuts = ({ onSort }: KeyboardShortcutsConfig): void => {
-  const conflictDetected = useRef(false);
+export const useKeyboardShortcuts = ({
+  onSort,
+  enabledSortOptions = SORT_OPTIONS,
+}: KeyboardShortcutsConfig): Set<string> => {
+  const [conflictKeys, setConflictKeys] = useState<Set<string>>(new Set());
+  const conflictKeysRef = useRef<Set<string>>(new Set());
   const checkedKeys = useRef(new Set<string>());
+
+  // Only keys whose sort is currently enabled are live; a disabled sort's key is inert
+  // (skipped before conflict detection, so pressing it neither sorts nor flags a conflict).
+  const activeKeys = useMemo(() => {
+    const enabled = new Set(enabledSortOptions.map((option) => option.sortBy));
+    return new Set<string>(TARGET_KEYS.filter((key) => enabled.has(KEY_TO_SORT[key])));
+  }, [enabledSortOptions]);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       const key = event.key.toLowerCase();
 
-      // Only care about our target keys
-      if (!TARGET_KEYS.includes(key as (typeof TARGET_KEYS)[number])) {
+      // Only care about our target keys, and only while their sort is enabled
+      if (!activeKeys.has(key)) {
         return;
       }
 
@@ -53,25 +69,25 @@ export const useKeyboardShortcuts = ({ onSort }: KeyboardShortcutsConfig): void 
         return;
       }
 
-      // Conflict detection: check each key once
+      // Conflict detection: check each key once, accumulating the keys another
+      // extension has claimed. Any conflict disables ALL our shortcuts (unchanged).
       if (!checkedKeys.current.has(key)) {
         checkedKeys.current.add(key);
         if (event.defaultPrevented) {
-          // Another extension handles this key - disable ALL our shortcuts
-          conflictDetected.current = true;
+          conflictKeysRef.current = new Set(conflictKeysRef.current).add(key);
+          setConflictKeys(conflictKeysRef.current);
         }
       }
 
-      // If conflict detected, don't handle any shortcuts
-      if (conflictDetected.current) {
+      if (conflictKeysRef.current.size > 0 || event.defaultPrevented) {
         return;
       }
 
       // Handle the sort
       event.preventDefault();
-      onSort(KEY_TO_SORT[key as (typeof TARGET_KEYS)[number]]);
+      onSort(KEY_TO_SORT[key as TargetKey]);
     },
-    [onSort],
+    [onSort, activeKeys],
   );
 
   useEffect(() => {
@@ -80,4 +96,6 @@ export const useKeyboardShortcuts = ({ onSort }: KeyboardShortcutsConfig): void 
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [handleKeyDown]);
+
+  return conflictKeys;
 };

--- a/app/hooks/useSettings.test.ts
+++ b/app/hooks/useSettings.test.ts
@@ -344,6 +344,137 @@ describe('useSettings', () => {
     });
   });
 
+  describe('derived sort toggles & validation', () => {
+    it('defaults both derived sorts to enabled', async () => {
+      setupTableBody([]);
+      const { result } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      const enabled = result.current.enabledSortOptions.map((o) => o.sortBy);
+      expect(enabled).toContain('velocity');
+      expect(enabled).toContain('heat');
+      expect(result.current.enabledSortOptions).toHaveLength(6);
+    });
+
+    it('reverts active velocity to default and shrinks the set when disabled (AE3)', async () => {
+      setupTableBody([]);
+      store[SETTINGS_KEYS.LAST_ACTIVE_SORT] = 'velocity';
+      const { result } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+      expect(result.current.activeSort).toBe('velocity');
+
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.VELOCITY_ENABLED]?.({ newValue: false });
+      });
+
+      expect(result.current.activeSort).toBe('default');
+      expect(result.current.enabledSortOptions.map((o) => o.sortBy)).not.toContain('velocity');
+    });
+
+    it('resolves a synced derived sort value to default when that sort is disabled', async () => {
+      setupTableBody([]);
+      store[SETTINGS_KEYS.HEAT_ENABLED] = false;
+      const { result } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      // Another device syncs its active sort as 'heat', but heat is disabled here.
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.LAST_ACTIVE_SORT]?.({ newValue: 'heat' });
+      });
+
+      expect(result.current.activeSort).toBe('default');
+    });
+
+    it('resolves stored velocity to default at page load when velocity is disabled', async () => {
+      setupTableBody([]);
+      store[SETTINGS_KEYS.VELOCITY_ENABLED] = false;
+      store[SETTINGS_KEYS.LAST_ACTIVE_SORT] = 'velocity';
+      const { result } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      expect(result.current.activeSort).toBe('default');
+    });
+
+    it('resolves an unknown stored variant to default at page load', async () => {
+      setupTableBody([]);
+      store[SETTINGS_KEYS.LAST_ACTIVE_SORT] = 'bogus';
+      const { result } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      expect(result.current.activeSort).toBe('default');
+    });
+
+    it('keeps stored velocity at page load when velocity is enabled', async () => {
+      setupTableBody([]);
+      store[SETTINGS_KEYS.LAST_ACTIVE_SORT] = 'velocity';
+      const { result } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      expect(result.current.activeSort).toBe('velocity');
+    });
+
+    it('leaves the active sort untouched when disabling a non-active derived sort', async () => {
+      setupTableBody([]);
+      store[SETTINGS_KEYS.LAST_ACTIVE_SORT] = 'points';
+      const { result } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.VELOCITY_ENABLED]?.({ newValue: false });
+      });
+
+      expect(result.current.activeSort).toBe('points');
+    });
+
+    it('never writes the resolved value back to storage (no ping-pong)', async () => {
+      setupTableBody([]);
+      store[SETTINGS_KEYS.VELOCITY_ENABLED] = false;
+      store[SETTINGS_KEYS.LAST_ACTIVE_SORT] = 'velocity';
+      const { result } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+      expect(result.current.activeSort).toBe('default');
+
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.HEAT_ENABLED]?.({ newValue: false });
+      });
+
+      expect(mockSet).not.toHaveBeenCalledWith(SETTINGS_KEYS.LAST_ACTIVE_SORT, expect.anything());
+    });
+
+    it('does not restore a stored derived sort on re-enable mid-session, but a reload does', async () => {
+      setupTableBody([]);
+      store[SETTINGS_KEYS.LAST_ACTIVE_SORT] = 'velocity';
+      const { result, unmount } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.VELOCITY_ENABLED]?.({ newValue: false });
+      });
+      expect(result.current.activeSort).toBe('default');
+
+      // Re-enable mid-session: stays default (stored value not restored)
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.VELOCITY_ENABLED]?.({ newValue: true });
+      });
+      expect(result.current.activeSort).toBe('default');
+
+      // Stored value was never overwritten, so a fresh mount (reload) restores velocity
+      unmount();
+      const { result: reloaded } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+      expect(reloaded.current.activeSort).toBe('velocity');
+    });
+
+    it('flips the settled flag only after the init read resolves', async () => {
+      setupTableBody([]);
+      const { result } = renderHook(() => useSettings());
+      expect(result.current.settled).toBe(false);
+
+      await act(() => Promise.resolve());
+      expect(result.current.settled).toBe(true);
+    });
+  });
+
   describe('memory leak prevention', () => {
     it('should call unwatch on unmount', async () => {
       setupTableBody([]);

--- a/app/hooks/useSettings.test.ts
+++ b/app/hooks/useSettings.test.ts
@@ -9,7 +9,7 @@ const COOLDOWN = SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN];
 const COOLDOWN_MS = COOLDOWN * 1000;
 
 // --- Storage mock ---
-const { store, mockSet, mockUnwatch, watcherCallbacks, reset, StorageClass } = createStorageMock();
+const { store, mockSet, mockGet, mockUnwatch, watcherCallbacks, reset, StorageClass } = createStorageMock();
 vi.mock('@plasmohq/storage', () => ({ Storage: StorageClass }));
 
 // --- Stubs ---
@@ -472,6 +472,54 @@ describe('useSettings', () => {
 
       await act(() => Promise.resolve());
       expect(result.current.settled).toBe(true);
+    });
+
+    it('still settles (with defaults) if a storage read rejects, so the panel never vanishes', async () => {
+      setupTableBody([]);
+      mockGet.mockRejectedValueOnce(new Error('extension context invalidated'));
+      const { result } = renderHook(() => useSettings());
+
+      await act(() => Promise.resolve());
+
+      expect(result.current.settled).toBe(true);
+    });
+
+    it('ignores toggle changes that arrive before init completes, then settles from the init read', async () => {
+      setupTableBody([]);
+      store[SETTINGS_KEYS.LAST_ACTIVE_SORT] = 'velocity';
+      const { result } = renderHook(() => useSettings());
+
+      // Watchers are live before init resolves; initializedRef is still false → guarded out.
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.VELOCITY_ENABLED]?.({ newValue: false });
+        watcherCallbacks[SETTINGS_KEYS.HEAT_ENABLED]?.({ newValue: false });
+      });
+
+      await act(() => Promise.resolve());
+
+      // init's own read wins over the ignored pre-init changes.
+      expect(result.current.settled).toBe(true);
+      expect(result.current.activeSort).toBe('velocity');
+      expect(result.current.enabledSortOptions.map((o) => o.sortBy)).toContain('velocity');
+    });
+
+    it('falls back to the default when a toggle watcher receives an undefined value', async () => {
+      setupTableBody([]);
+      store[SETTINGS_KEYS.VELOCITY_ENABLED] = false;
+      store[SETTINGS_KEYS.HEAT_ENABLED] = false;
+      const { result } = renderHook(() => useSettings());
+      await act(() => Promise.resolve());
+      expect(result.current.enabledSortOptions).toHaveLength(4);
+
+      // A cleared key (undefined newValue) resets to the default (enabled).
+      act(() => {
+        watcherCallbacks[SETTINGS_KEYS.VELOCITY_ENABLED]?.({ newValue: undefined });
+        watcherCallbacks[SETTINGS_KEYS.HEAT_ENABLED]?.({ newValue: undefined });
+      });
+
+      const enabled = result.current.enabledSortOptions.map((o) => o.sortBy);
+      expect(enabled).toContain('velocity');
+      expect(enabled).toContain('heat');
     });
   });
 

--- a/app/hooks/useSettings.test.ts
+++ b/app/hooks/useSettings.test.ts
@@ -489,7 +489,7 @@ describe('useSettings', () => {
       store[SETTINGS_KEYS.LAST_ACTIVE_SORT] = 'velocity';
       const { result } = renderHook(() => useSettings());
 
-      // Watchers are live before init resolves; initializedRef is still false → guarded out.
+      // Watchers are live before init resolves; sortsReadyRef is still false → guarded out.
       act(() => {
         watcherCallbacks[SETTINGS_KEYS.VELOCITY_ENABLED]?.({ newValue: false });
         watcherCallbacks[SETTINGS_KEYS.HEAT_ENABLED]?.({ newValue: false });

--- a/app/hooks/useSettings.ts
+++ b/app/hooks/useSettings.ts
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Storage, type StorageCallbackMap } from '@plasmohq/storage';
 
-import { CSS_CLASSES, SETTINGS_DEFAULTS, SETTINGS_KEYS } from '~app/constants';
-import type { SortVariant } from '~app/types';
+import { CSS_CLASSES, SETTINGS_DEFAULTS, SETTINGS_KEYS, SORT_OPTIONS } from '~app/constants';
+import type { SortOption, SortVariant } from '~app/types';
 import type { PostTimestamps } from '~app/utils/newPosts';
 import {
   clearNewPostMarkers,
@@ -19,15 +19,32 @@ const storage = new Storage();
 
 const getPostIdsKey = (): string => `${SETTINGS_KEYS.POST_IDS_PREFIX}${window.location.pathname}`;
 
+// A stored/synced sort value that is unknown (newer version) or currently disabled
+// resolves to HN's default order (R6). This is the single convergence point for all
+// sort-value entry points: init read, last-active-sort watcher, and toggle watchers.
+const resolveActiveSort = (stored: SortVariant, velocityEnabled: boolean, heatEnabled: boolean): SortVariant => {
+  if (!SORT_OPTIONS.some((option) => option.sortBy === stored)) return 'default';
+  if (stored === 'velocity' && !velocityEnabled) return 'default';
+  if (stored === 'heat' && !heatEnabled) return 'default';
+  return stored;
+};
+
 type UseSettingsReturn = {
   activeSort: SortVariant;
   setActiveSort: (sort: SortVariant) => void;
   showTrueTimeAgo: boolean;
+  enabledSortOptions: SortOption[];
+  settled: boolean;
 };
 
 export const useSettings = (): UseSettingsReturn => {
   const [activeSort, setActiveSortState] = useState<SortVariant>(SETTINGS_DEFAULTS[SETTINGS_KEYS.LAST_ACTIVE_SORT]);
   const [showTrueTimeAgo, setShowTrueTimeAgoState] = useState(SETTINGS_DEFAULTS[SETTINGS_KEYS.TRUE_TIME_AGO]);
+  const [velocityEnabled, setVelocityEnabledState] = useState(SETTINGS_DEFAULTS[SETTINGS_KEYS.VELOCITY_ENABLED]);
+  const [heatEnabled, setHeatEnabledState] = useState(SETTINGS_DEFAULTS[SETTINGS_KEYS.HEAT_ENABLED]);
+  const [settled, setSettled] = useState(false);
+  const velocityEnabledRef = useRef(SETTINGS_DEFAULTS[SETTINGS_KEYS.VELOCITY_ENABLED]);
+  const heatEnabledRef = useRef(SETTINGS_DEFAULTS[SETTINGS_KEYS.HEAT_ENABLED]);
   const initializedRef = useRef(false);
   const timestampsRef = useRef<PostTimestamps>({});
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -80,8 +97,21 @@ export const useSettings = (): UseSettingsReturn => {
       showNewRef.current = showNewValue;
       applyShowNew(showNewValue);
 
+      const velocity = await storage.get<boolean>(SETTINGS_KEYS.VELOCITY_ENABLED);
+      const velocityValue = velocity ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.VELOCITY_ENABLED];
+      velocityEnabledRef.current = velocityValue;
+      setVelocityEnabledState(velocityValue);
+
+      const heat = await storage.get<boolean>(SETTINGS_KEYS.HEAT_ENABLED);
+      const heatValue = heat ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.HEAT_ENABLED];
+      heatEnabledRef.current = heatValue;
+      setHeatEnabledState(heatValue);
+
       const sort = await storage.get<SortVariant>(SETTINGS_KEYS.LAST_ACTIVE_SORT);
-      setActiveSortState(sort ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.LAST_ACTIVE_SORT]);
+      setActiveSortState(
+        resolveActiveSort(sort ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.LAST_ACTIVE_SORT], velocityValue, heatValue),
+      );
+      setSettled(true);
 
       const cooldown = await storage.get<number>(SETTINGS_KEYS.COOLDOWN);
       cooldownRef.current = cooldown ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN];
@@ -137,9 +167,22 @@ export const useSettings = (): UseSettingsReturn => {
       },
       [SETTINGS_KEYS.LAST_ACTIVE_SORT]: (change) => {
         if (!initializedRef.current) return;
-        setActiveSortState(
-          (change.newValue as SortVariant | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.LAST_ACTIVE_SORT],
-        );
+        const incoming =
+          (change.newValue as SortVariant | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.LAST_ACTIVE_SORT];
+        // Resolve locally (revert-on-disable); never write the resolved value back (no ping-pong).
+        setActiveSortState(resolveActiveSort(incoming, velocityEnabledRef.current, heatEnabledRef.current));
+      },
+      [SETTINGS_KEYS.VELOCITY_ENABLED]: (change) => {
+        const enabled = (change.newValue as boolean | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.VELOCITY_ENABLED];
+        velocityEnabledRef.current = enabled;
+        setVelocityEnabledState(enabled);
+        setActiveSortState((prev) => resolveActiveSort(prev, enabled, heatEnabledRef.current));
+      },
+      [SETTINGS_KEYS.HEAT_ENABLED]: (change) => {
+        const enabled = (change.newValue as boolean | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.HEAT_ENABLED];
+        heatEnabledRef.current = enabled;
+        setHeatEnabledState(enabled);
+        setActiveSortState((prev) => resolveActiveSort(prev, velocityEnabledRef.current, enabled));
       },
       [SETTINGS_KEYS.TRUE_TIME_AGO]: (change) => {
         setShowTrueTimeAgoState(
@@ -184,5 +227,13 @@ export const useSettings = (): UseSettingsReturn => {
     };
   }, []);
 
-  return { activeSort, setActiveSort, showTrueTimeAgo };
+  const enabledSortOptions = useMemo(
+    () =>
+      SORT_OPTIONS.filter(
+        (option) => (option.sortBy !== 'velocity' || velocityEnabled) && (option.sortBy !== 'heat' || heatEnabled),
+      ),
+    [velocityEnabled, heatEnabled],
+  );
+
+  return { activeSort, setActiveSort, showTrueTimeAgo, enabledSortOptions, settled };
 };

--- a/app/hooks/useSettings.ts
+++ b/app/hooks/useSettings.ts
@@ -19,15 +19,21 @@ const storage = new Storage();
 
 const getPostIdsKey = (): string => `${SETTINGS_KEYS.POST_IDS_PREFIX}${window.location.pathname}`;
 
-// A stored/synced sort value that is unknown (newer version) or currently disabled
-// resolves to HN's default order (R6). This is the single convergence point for all
-// sort-value entry points: init read, last-active-sort watcher, and toggle watchers.
-const resolveActiveSort = (stored: SortVariant, velocityEnabled: boolean, heatEnabled: boolean): SortVariant => {
-  if (!SORT_OPTIONS.some((option) => option.sortBy === stored)) return 'default';
-  if (stored === 'velocity' && !velocityEnabled) return 'default';
-  if (stored === 'heat' && !heatEnabled) return 'default';
-  return stored;
-};
+// The set of currently-selectable sorts: every SORT_OPTIONS variant minus any whose disable
+// toggle is off. Single source of truth that BOTH revert-on-disable (resolveActiveSort) and the
+// rendered option list (enabledSortOptions) read from, so the two can't drift. To add a toggle,
+// extend the filter here plus SETTINGS_KEYS/DEFAULTS and the init read + watcher below.
+const enabledSortSet = (velocityEnabled: boolean, heatEnabled: boolean): Set<SortVariant> =>
+  new Set(
+    SORT_OPTIONS.map((option) => option.sortBy).filter(
+      (sort) => (sort !== 'velocity' || velocityEnabled) && (sort !== 'heat' || heatEnabled),
+    ),
+  );
+
+// A stored/synced sort value that is unknown (newer version) or currently disabled resolves to
+// HN's default order (R6). Convergence point for every entry: init read + all watchers.
+const resolveActiveSort = (stored: SortVariant, velocityEnabled: boolean, heatEnabled: boolean): SortVariant =>
+  enabledSortSet(velocityEnabled, heatEnabled).has(stored) ? stored : 'default';
 
 type UseSettingsReturn = {
   activeSort: SortVariant;
@@ -140,7 +146,11 @@ export const useSettings = (): UseSettingsReturn => {
       initializedRef.current = true;
     };
 
-    init();
+    // Never let a rejected storage read block first paint forever (e.g. "extension context
+    // invalidated" during a mid-session update): degrade to defaults instead of a vanished panel.
+    init().catch(() => {
+      if (mountedRef.current) setSettled(true);
+    });
 
     // --- Watchers ---
     const watcherMap: StorageCallbackMap = {
@@ -173,12 +183,14 @@ export const useSettings = (): UseSettingsReturn => {
         setActiveSortState(resolveActiveSort(incoming, velocityEnabledRef.current, heatEnabledRef.current));
       },
       [SETTINGS_KEYS.VELOCITY_ENABLED]: (change) => {
+        if (!initializedRef.current) return; // defer to init's own read (matches LAST_ACTIVE_SORT)
         const enabled = (change.newValue as boolean | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.VELOCITY_ENABLED];
         velocityEnabledRef.current = enabled;
         setVelocityEnabledState(enabled);
         setActiveSortState((prev) => resolveActiveSort(prev, enabled, heatEnabledRef.current));
       },
       [SETTINGS_KEYS.HEAT_ENABLED]: (change) => {
+        if (!initializedRef.current) return; // defer to init's own read (matches LAST_ACTIVE_SORT)
         const enabled = (change.newValue as boolean | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.HEAT_ENABLED];
         heatEnabledRef.current = enabled;
         setHeatEnabledState(enabled);
@@ -227,13 +239,10 @@ export const useSettings = (): UseSettingsReturn => {
     };
   }, []);
 
-  const enabledSortOptions = useMemo(
-    () =>
-      SORT_OPTIONS.filter(
-        (option) => (option.sortBy !== 'velocity' || velocityEnabled) && (option.sortBy !== 'heat' || heatEnabled),
-      ),
-    [velocityEnabled, heatEnabled],
-  );
+  const enabledSortOptions = useMemo(() => {
+    const enabled = enabledSortSet(velocityEnabled, heatEnabled);
+    return SORT_OPTIONS.filter((option) => enabled.has(option.sortBy));
+  }, [velocityEnabled, heatEnabled]);
 
   return { activeSort, setActiveSort, showTrueTimeAgo, enabledSortOptions, settled };
 };

--- a/app/hooks/useSettings.ts
+++ b/app/hooks/useSettings.ts
@@ -52,6 +52,10 @@ export const useSettings = (): UseSettingsReturn => {
   const velocityEnabledRef = useRef(SETTINGS_DEFAULTS[SETTINGS_KEYS.VELOCITY_ENABLED]);
   const heatEnabledRef = useRef(SETTINGS_DEFAULTS[SETTINGS_KEYS.HEAT_ENABLED]);
   const initializedRef = useRef(false);
+  // Sort/toggle watchers only need their own values read + the panel painted (setSettled) to go
+  // live — earlier than initializedRef, which stays gated until init's own postIds write lands so
+  // the postIds watcher doesn't react to it (KTD-6, no ping-pong).
+  const sortsReadyRef = useRef(false);
   const timestampsRef = useRef<PostTimestamps>({});
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const cooldownRef = useRef<number>(SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN]);
@@ -118,6 +122,7 @@ export const useSettings = (): UseSettingsReturn => {
         resolveActiveSort(sort ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.LAST_ACTIVE_SORT], velocityValue, heatValue),
       );
       setSettled(true);
+      sortsReadyRef.current = true;
 
       const cooldown = await storage.get<number>(SETTINGS_KEYS.COOLDOWN);
       cooldownRef.current = cooldown ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.COOLDOWN];
@@ -176,21 +181,21 @@ export const useSettings = (): UseSettingsReturn => {
         }
       },
       [SETTINGS_KEYS.LAST_ACTIVE_SORT]: (change) => {
-        if (!initializedRef.current) return;
+        if (!sortsReadyRef.current) return;
         const incoming =
           (change.newValue as SortVariant | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.LAST_ACTIVE_SORT];
         // Resolve locally (revert-on-disable); never write the resolved value back (no ping-pong).
         setActiveSortState(resolveActiveSort(incoming, velocityEnabledRef.current, heatEnabledRef.current));
       },
       [SETTINGS_KEYS.VELOCITY_ENABLED]: (change) => {
-        if (!initializedRef.current) return; // defer to init's own read (matches LAST_ACTIVE_SORT)
+        if (!sortsReadyRef.current) return; // live once sort/toggle reads + first paint are done
         const enabled = (change.newValue as boolean | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.VELOCITY_ENABLED];
         velocityEnabledRef.current = enabled;
         setVelocityEnabledState(enabled);
         setActiveSortState((prev) => resolveActiveSort(prev, enabled, heatEnabledRef.current));
       },
       [SETTINGS_KEYS.HEAT_ENABLED]: (change) => {
-        if (!initializedRef.current) return; // defer to init's own read (matches LAST_ACTIVE_SORT)
+        if (!sortsReadyRef.current) return; // live once sort/toggle reads + first paint are done
         const enabled = (change.newValue as boolean | undefined) ?? SETTINGS_DEFAULTS[SETTINGS_KEYS.HEAT_ENABLED];
         heatEnabledRef.current = enabled;
         setHeatEnabledState(enabled);

--- a/app/popup.test.tsx
+++ b/app/popup.test.tsx
@@ -1,14 +1,16 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { COOLDOWN_BOUNDS, SETTINGS_KEYS } from '~app/constants';
 
 let storageValues: Record<string, unknown> = {};
+const setters: Record<string, ReturnType<typeof vi.fn>> = {};
 
 vi.mock('@plasmohq/storage/hook', () => ({
   useStorage: (key: string, defaultValue: unknown) => {
     const value = key in storageValues ? storageValues[key] : defaultValue;
-    return [value, vi.fn()];
+    setters[key] = setters[key] ?? vi.fn();
+    return [value, setters[key]];
   },
 }));
 
@@ -79,5 +81,23 @@ describe('Popup', () => {
 
     const input = screen.getByLabelText('Highlight duration in seconds') as HTMLInputElement;
     expect(input.value).toBe('300');
+  });
+
+  it('should render Velocity and Heat toggles reflecting stored state', () => {
+    storageValues = { [SETTINGS_KEYS.VELOCITY_ENABLED]: true, [SETTINGS_KEYS.HEAT_ENABLED]: false };
+    render(<Popup />);
+
+    expect((screen.getByLabelText('Velocity sort') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByLabelText('Heat sort') as HTMLInputElement).checked).toBe(false);
+  });
+
+  it('should write the new value when a derived-sort toggle is clicked', () => {
+    storageValues = { [SETTINGS_KEYS.VELOCITY_ENABLED]: true };
+    render(<Popup />);
+
+    const setVelocity = setters[SETTINGS_KEYS.VELOCITY_ENABLED];
+    setVelocity.mockClear();
+    fireEvent.click(screen.getByLabelText('Velocity sort'));
+    expect(setVelocity).toHaveBeenCalledWith(false);
   });
 });

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,5 +1,4 @@
-export type SortVariant = 'default' | 'points' | 'time' | 'comments';
-export type NonDefaultSortVariant = Exclude<SortVariant, 'default'>;
+export type SortVariant = 'default' | 'points' | 'time' | 'comments' | 'velocity' | 'heat';
 
 export type ParsedRow = {
   originalIndex: number;

--- a/app/utils/presenters.test.ts
+++ b/app/utils/presenters.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CSS_CLASSES, HN_CLASSES, SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE } from '~app/constants';
-import type { ParsedRow } from '~app/types';
+import type { ParsedRow, SortVariant } from '~app/types';
 import { nowInSeconds } from '~app/utils/converters';
 
 import { correctAgeTexts, formatAge, highlightActiveSort, restoreAgeTexts } from './presenters';
@@ -43,6 +43,17 @@ describe('presenters', () => {
 
     it('should not add highlight for default sort', () => {
       highlightActiveSort(infoRow, 'default');
+      expect(infoRow.querySelector(`.${CSS_CLASSES.HIGHLIGHT}`)).toBeNull();
+    });
+
+    it('should not highlight (or throw) for derived sorts velocity/heat', () => {
+      expect(() => highlightActiveSort(infoRow, 'velocity')).not.toThrow();
+      expect(() => highlightActiveSort(infoRow, 'heat')).not.toThrow();
+      expect(infoRow.querySelector(`.${CSS_CLASSES.HIGHLIGHT}`)).toBeNull();
+    });
+
+    it('should not throw for an unknown variant arriving via sync', () => {
+      expect(() => highlightActiveSort(infoRow, 'bogus' as SortVariant)).not.toThrow();
       expect(infoRow.querySelector(`.${CSS_CLASSES.HIGHLIGHT}`)).toBeNull();
     });
 

--- a/app/utils/presenters.ts
+++ b/app/utils/presenters.ts
@@ -1,5 +1,5 @@
 import { CSS_CLASSES, CSS_SELECTORS, SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE } from '~app/constants';
-import type { NonDefaultSortVariant, ParsedRow, SortVariant } from '~app/types';
+import type { ParsedRow, SortVariant } from '~app/types';
 import { nowInSeconds } from '~app/utils/converters';
 import { getCommentsElement, getPointsElement, getTableBody, getTimeElement } from '~app/utils/selectors';
 
@@ -26,7 +26,10 @@ export const updateTable = (parsedRows: ParsedRow[], footerRows: HTMLElement[], 
   tableBody.replaceChildren(fragment);
 };
 
-const SORT_TO_ELEMENT_GETTER: Record<NonDefaultSortVariant, (row: HTMLElement) => HTMLElement | null> = {
+// Only single-column sorts have a highlight target. Variants without an entry here
+// (default, velocity/heat which span two columns, or an unknown value arriving via
+// cross-device sync from a newer version) take the early return below and never crash.
+const SORT_TO_ELEMENT_GETTER: Partial<Record<SortVariant, (row: HTMLElement) => HTMLElement | null>> = {
   points: getPointsElement,
   time: getTimeElement,
   comments: getCommentsElement,
@@ -39,11 +42,11 @@ export const highlightActiveSort = (infoRow: HTMLElement, activeSort: SortVarian
     previousHighlight.classList.remove(CSS_CLASSES.HIGHLIGHT);
   }
 
-  if (activeSort === 'default') {
+  const elementGetter = SORT_TO_ELEMENT_GETTER[activeSort];
+  if (!elementGetter) {
     return infoRow;
   }
 
-  const elementGetter = SORT_TO_ELEMENT_GETTER[activeSort];
   const elementToHighlight = elementGetter(infoRow);
 
   if (elementToHighlight) {

--- a/app/utils/sorters.test.ts
+++ b/app/utils/sorters.test.ts
@@ -106,6 +106,17 @@ describe('sorters', () => {
       // huge age → tiny finite velocity → ranks last, never NaN/Infinity
       expect(sorted.map((r) => r.originalIndex)).toEqual([0, 1]);
     });
+
+    it('clamps a future-dated post (clock skew) so velocity stays finite and positive', () => {
+      // Client clock 5h behind this post's server timestamp → raw age is negative.
+      const future = createMockRow({ originalIndex: 0, points: 100, time: NOW_SEC + 5 * SECONDS_PER_HOUR });
+      const normal = createMockRow({ originalIndex: 1, points: 100, time: NOW_SEC - SECONDS_PER_HOUR });
+      let sorted: ParsedRow[] = [];
+      expect(() => (sorted = sortRows([future, normal], 'velocity'))).not.toThrow();
+      // age clamps to 0 → 100/2 = 50 (finite, positive), above normal's 100/3 ≈ 33.3;
+      // without the clamp the denominator would go negative and wrongly sink it last.
+      expect(sorted.map((r) => r.originalIndex)).toEqual([0, 1]);
+    });
   });
 
   describe('heat', () => {

--- a/app/utils/sorters.test.ts
+++ b/app/utils/sorters.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { FAKE_NOW } from '~app/__fixtures__/testHelpers';
+import { SECONDS_PER_HOUR, SECONDS_PER_MINUTE } from '~app/constants';
 import type { ParsedRow } from '~app/types';
 
 import { sortRows } from './sorters';
+
+const NOW_SEC = Math.floor(FAKE_NOW / 1000);
 
 const createMockRow = (overrides: Partial<ParsedRow>): ParsedRow => ({
   originalIndex: 0,
@@ -69,6 +73,80 @@ describe('sorters', () => {
       ];
       const sorted = sortRows(equalRows, 'points');
       expect(sorted.map((r) => r.points)).toEqual([100, 100, 100]);
+    });
+  });
+
+  describe('velocity', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(FAKE_NOW);
+    });
+    afterEach(() => vi.useRealTimers());
+
+    it('ranks an older higher-point post above a fresh low-point one (AE1, damping)', () => {
+      const young = createMockRow({ originalIndex: 0, points: 15, time: NOW_SEC - 20 * SECONDS_PER_MINUTE });
+      const older = createMockRow({ originalIndex: 1, points: 60, time: NOW_SEC - 3 * SECONDS_PER_HOUR });
+      const sorted = sortRows([young, older], 'velocity');
+      expect(sorted.map((r) => r.originalIndex)).toEqual([1, 0]);
+    });
+
+    it('converges to raw points/hour for old posts', () => {
+      // old1 rate ~10/h, old2 rate ~5/h — damping barely shifts multi-day posts
+      const old1 = createMockRow({ originalIndex: 0, points: 720, time: NOW_SEC - 72 * SECONDS_PER_HOUR });
+      const old2 = createMockRow({ originalIndex: 1, points: 600, time: NOW_SEC - 120 * SECONDS_PER_HOUR });
+      const sorted = sortRows([old2, old1], 'velocity');
+      expect(sorted.map((r) => r.originalIndex)).toEqual([0, 1]);
+    });
+
+    it('gives a finite velocity for a zero/missing time and does not throw', () => {
+      const recent = createMockRow({ originalIndex: 0, points: 100, time: NOW_SEC - SECONDS_PER_HOUR });
+      const noTime = createMockRow({ originalIndex: 1, points: 100, time: 0 });
+      let sorted: ParsedRow[] = [];
+      expect(() => (sorted = sortRows([recent, noTime], 'velocity'))).not.toThrow();
+      // huge age → tiny finite velocity → ranks last, never NaN/Infinity
+      expect(sorted.map((r) => r.originalIndex)).toEqual([0, 1]);
+    });
+  });
+
+  describe('heat', () => {
+    it('ranks a higher comments/points ratio first', () => {
+      const chatty = createMockRow({ originalIndex: 0, points: 50, comments: 100 });
+      const quiet = createMockRow({ originalIndex: 1, points: 50, comments: 10 });
+      const sorted = sortRows([quiet, chatty], 'heat');
+      expect(sorted.map((r) => r.originalIndex)).toEqual([0, 1]);
+    });
+
+    it('sorts a 0-point/0-comment job post last with no NaN (AE2)', () => {
+      const post = createMockRow({ originalIndex: 0, points: 50, comments: 10 });
+      const job = createMockRow({ originalIndex: 1, points: 0, comments: 0 });
+      const sorted = sortRows([job, post], 'heat');
+      expect(sorted.map((r) => r.originalIndex)).toEqual([0, 1]);
+    });
+
+    it('sorts a 0-point post with comments last (the Infinity trap)', () => {
+      const post = createMockRow({ originalIndex: 0, points: 50, comments: 10 });
+      const job = createMockRow({ originalIndex: 1, points: 0, comments: 100 });
+      const sorted = sortRows([job, post], 'heat');
+      expect(sorted.map((r) => r.originalIndex)).toEqual([0, 1]);
+    });
+  });
+
+  describe('immutability of derived sorts', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(FAKE_NOW);
+    });
+    afterEach(() => vi.useRealTimers());
+
+    it('does not mutate the input array', () => {
+      const rows = [
+        createMockRow({ originalIndex: 0, points: 60, comments: 100, time: NOW_SEC - SECONDS_PER_HOUR }),
+        createMockRow({ originalIndex: 1, points: 0, comments: 0, time: NOW_SEC - 2 * SECONDS_PER_HOUR }),
+      ];
+      const snapshot = [...rows];
+      sortRows(rows, 'velocity');
+      sortRows(rows, 'heat');
+      expect(rows).toEqual(snapshot);
     });
   });
 });

--- a/app/utils/sorters.ts
+++ b/app/utils/sorters.ts
@@ -12,7 +12,9 @@ const VELOCITY_DAMPING_HOURS = 2;
 const HEAT_ZERO_POINTS_SENTINEL = -1;
 
 const velocity = (row: ParsedRow): number => {
-  const ageHours = (nowInSeconds() - row.time) / SECONDS_PER_HOUR;
+  // Clamp age at 0 so a client clock running behind a post's server timestamp can't drive the
+  // denominator to zero/negative (Infinity/NaN/negative rank); keeps the no-Infinity/NaN guarantee.
+  const ageHours = Math.max(0, (nowInSeconds() - row.time) / SECONDS_PER_HOUR);
   return row.points / (ageHours + VELOCITY_DAMPING_HOURS);
 };
 

--- a/app/utils/sorters.ts
+++ b/app/utils/sorters.ts
@@ -1,7 +1,22 @@
+import { SECONDS_PER_HOUR } from '~app/constants';
 import type { ParsedRow, SortVariant } from '~app/types';
+import { nowInSeconds } from '~app/utils/converters';
 
 type SortableKey = Extract<keyof ParsedRow, 'points' | 'time' | 'comments' | 'originalIndex'>;
 type SortOrder = 'asc' | 'desc';
+
+// Damped velocity denominator, mirroring HN's own gravity formula shape (age + 2).
+const VELOCITY_DAMPING_HOURS = 2;
+// 0-points rows (e.g. job posts) can't yield a real comments/points ratio; a finite
+// below-zero sentinel sinks them to the bottom without the Infinity/NaN of naive division.
+const HEAT_ZERO_POINTS_SENTINEL = -1;
+
+const velocity = (row: ParsedRow): number => {
+  const ageHours = (nowInSeconds() - row.time) / SECONDS_PER_HOUR;
+  return row.points / (ageHours + VELOCITY_DAMPING_HOURS);
+};
+
+const heat = (row: ParsedRow): number => (row.points === 0 ? HEAT_ZERO_POINTS_SENTINEL : row.comments / row.points);
 
 export const sortRows = (parsedRows: ParsedRow[], sortBy: SortVariant): ParsedRow[] => {
   switch (sortBy) {
@@ -11,6 +26,10 @@ export const sortRows = (parsedRows: ParsedRow[], sortBy: SortVariant): ParsedRo
       return sortByKey(parsedRows, 'time');
     case 'comments':
       return sortByKey(parsedRows, 'comments');
+    case 'velocity':
+      return sortByValue(parsedRows, velocity);
+    case 'heat':
+      return sortByValue(parsedRows, heat);
     default:
       return sortByKey(parsedRows, 'originalIndex', 'asc');
   }
@@ -20,4 +39,8 @@ const sortByKey = (parsedRows: ParsedRow[], key: SortableKey, order: SortOrder =
   return [...parsedRows].sort((rowA, rowB) => {
     return order === 'asc' ? rowA[key] - rowB[key] : rowB[key] - rowA[key];
   });
+};
+
+const sortByValue = (parsedRows: ParsedRow[], valueOf: (row: ParsedRow) => number): ParsedRow[] => {
+  return [...parsedRows].sort((rowA, rowB) => valueOf(rowB) - valueOf(rowA));
 };

--- a/content.css
+++ b/content.css
@@ -63,19 +63,18 @@
   color: #828282;
 }
 
-/* Mobile dropdown tier — hidden until the small-screen breakpoint below */
+/* Dropdown tier — hidden until the count-aware collapse breakpoints below */
 .hns-dropdown-tier {
   display: none;
-}
-
-.hns-dropdown-label {
-  margin-right: 5px;
-  color: #000;
 }
 
 .hns-dropdown {
   font: inherit;
   color: #000;
+  /* A native <select> sizes to its widest option ("comments"/"velocity" ~92px), leaving a loose
+   * gap after short values like "points". Cap it so short values sit snug; the two long words clip
+   * by a hair — Chrome keeps the arrow and clips the text, and it's still clear what the control is. */
+  max-width: 84px;
 }
 
 /*
@@ -114,14 +113,52 @@
   }
 }
 
-/* Tier 3 (dropdown) — fixed small-screen breakpoint, independent of option count */
-@media screen and (max-width: 600px) {
-  .hns-buttons-tier {
+/*
+ * Tier 2↔3 (letters ↔ dropdown). Also count-aware: the single-letter buttons row is still wide
+ * enough to push HN's own nav onto a second line once the viewport is narrow, so we collapse to a
+ * compact native <select> *before* that happens. Each breakpoint sits just above the width at which
+ * the letters row starts wrapping HN's nav for that option count (measured against HN's header:
+ * ~1044/1084/1124px for 4/5/6 options — +margin below). The label-less dropdown is then as narrow as
+ * the header allows, so it never wraps the nav until HN's nav would wrap on its own (~750px).
+ */
+@media screen and (max-width: 1080px) {
+  #hns-control-panel[data-sort-count='4'] .hns-buttons-tier {
     display: none;
   }
 
-  .hns-dropdown-tier {
+  #hns-control-panel[data-sort-count='4'] .hns-dropdown-tier {
     display: inline-block;
+  }
+}
+
+@media screen and (max-width: 1120px) {
+  #hns-control-panel[data-sort-count='5'] .hns-buttons-tier {
+    display: none;
+  }
+
+  #hns-control-panel[data-sort-count='5'] .hns-dropdown-tier {
+    display: inline-block;
+  }
+}
+
+@media screen and (max-width: 1160px) {
+  #hns-control-panel[data-sort-count='6'] .hns-buttons-tier {
+    display: none;
+  }
+
+  #hns-control-panel[data-sort-count='6'] .hns-dropdown-tier {
+    display: inline-block;
+  }
+}
+
+/*
+ * Below ~750px HN's header wraps to multiple lines — the login/username drops to its own line
+ * beneath our <select>, which strands the trailing "|" at the end of a line with nothing after it.
+ * Drop the separator there (it's only meaningful while the select and the header links share a line).
+ */
+@media screen and (max-width: 750px) {
+  .hns-dropdown-tier .hns-divider {
+    display: none;
   }
 }
 

--- a/content.css
+++ b/content.css
@@ -57,13 +57,71 @@
   font-weight: bold;
 }
 
+.hns-conflict-note {
+  margin-left: 10px;
+  font-size: 11px;
+  color: #828282;
+}
+
+/* Mobile dropdown tier — hidden until the small-screen breakpoint below */
+.hns-dropdown-tier {
+  display: none;
+}
+
+.hns-dropdown-label {
+  margin-right: 5px;
+  color: #000;
+}
+
+.hns-dropdown {
+  font: inherit;
+  color: #000;
+}
+
+/*
+ * Tier 1↔2 (full names ↔ letters). The switch point is count-aware: more options
+ * need more width before full names fit, so each enabled-option count (4–6) gets its
+ * own breakpoint keyed off the data-sort-count attribute on the panel root (KTD-3).
+ * Values calibrated against HN's header; 1280px is the original 4-option baseline.
+ */
 @media screen and (min-width: 1280px) {
-  .hns-btn-text {
+  #hns-control-panel[data-sort-count='4'] .hns-btn-text {
     display: inline;
   }
 
-  .hns-btn-shortcut {
+  #hns-control-panel[data-sort-count='4'] .hns-btn-shortcut {
     display: none;
+  }
+}
+
+@media screen and (min-width: 1360px) {
+  #hns-control-panel[data-sort-count='5'] .hns-btn-text {
+    display: inline;
+  }
+
+  #hns-control-panel[data-sort-count='5'] .hns-btn-shortcut {
+    display: none;
+  }
+}
+
+@media screen and (min-width: 1440px) {
+  #hns-control-panel[data-sort-count='6'] .hns-btn-text {
+    display: inline;
+  }
+
+  #hns-control-panel[data-sort-count='6'] .hns-btn-shortcut {
+    display: none;
+  }
+}
+
+/* Tier 3 (dropdown) — fixed small-screen breakpoint, independent of option count */
+@media screen and (max-width: 600px) {
+  .hns-buttons-tier {
+    display: none;
+  }
+
+  .hns-dropdown-tier {
+    display: inline-block;
   }
 }
 

--- a/popup.tsx
+++ b/popup.tsx
@@ -13,6 +13,8 @@ const Popup = () => {
   const [showNew, setShowNew] = useSettingsStorage(SETTINGS_KEYS.SHOW_NEW);
   const [cooldown, setCooldown] = useSettingsStorage(SETTINGS_KEYS.COOLDOWN);
   const [trueTimeAgo, setTrueTimeAgo] = useSettingsStorage(SETTINGS_KEYS.TRUE_TIME_AGO);
+  const [velocityEnabled, setVelocityEnabled] = useSettingsStorage(SETTINGS_KEYS.VELOCITY_ENABLED);
+  const [heatEnabled, setHeatEnabled] = useSettingsStorage(SETTINGS_KEYS.HEAT_ENABLED);
   const [layoutOk] = useSettingsStorage(SETTINGS_KEYS.LAYOUT_OK);
   // useStorage renders with the default value first, then async-loads the stored value.
   // When stored !== default, the CSS transition animates the toggle visibly (on→off flash).
@@ -97,6 +99,42 @@ const Popup = () => {
               aria-label="Show true time ago setting"
               checked={trueTimeAgo}
               onChange={(e) => setTrueTimeAgo(e.target.checked)}
+            />
+            <span className="hns-toggle-slider" />
+          </label>
+        </div>
+      </fieldset>
+
+      <fieldset className="hns-group">
+        <div className="hns-setting">
+          <div className="hns-setting-label">
+            <span>Velocity sort</span>
+            <span className="hns-hint">Adds a sort for the fastest-rising posts (points per hour)</span>
+          </div>
+          <label className="hns-toggle">
+            <input
+              type="checkbox"
+              name="velocity-enabled"
+              aria-label="Velocity sort"
+              checked={velocityEnabled}
+              onChange={(e) => setVelocityEnabled(e.target.checked)}
+            />
+            <span className="hns-toggle-slider" />
+          </label>
+        </div>
+
+        <div className="hns-setting">
+          <div className="hns-setting-label">
+            <span>Heat sort</span>
+            <span className="hns-hint">Adds a sort for the most-discussed posts (comments per point)</span>
+          </div>
+          <label className="hns-toggle">
+            <input
+              type="checkbox"
+              name="heat-enabled"
+              aria-label="Heat sort"
+              checked={heatEnabled}
+              onChange={(e) => setHeatEnabled(e.target.checked)}
             />
             <span className="hns-toggle-slider" />
           </label>

--- a/popup.tsx
+++ b/popup.tsx
@@ -109,7 +109,11 @@ const Popup = () => {
         <div className="hns-setting">
           <div className="hns-setting-label">
             <span>Velocity sort</span>
-            <span className="hns-hint">Adds a sort for the fastest-rising posts (points per hour)</span>
+            <span className="hns-hint">
+              Adds a sort for the fastest-rising posts
+              <br />
+              (points per hour)
+            </span>
           </div>
           <label className="hns-toggle">
             <input
@@ -126,7 +130,11 @@ const Popup = () => {
         <div className="hns-setting">
           <div className="hns-setting-label">
             <span>Heat sort</span>
-            <span className="hns-hint">Adds a sort for the most-discussed posts (comments per point)</span>
+            <span className="hns-hint">
+              Adds a sort for the most-discussed posts
+              <br />
+              (comments per point)
+            </span>
           </div>
           <label className="hns-toggle">
             <input


### PR DESCRIPTION
## What

Implements the [Derived Sorts (Velocity + Heat) plan](docs/plans/2026-07-02-001-feat-derived-sorts-plan.md).

Two new sort options, computed from data the extension already parses per row (no new parsing/storage/network):

- **Velocity** — `points / (age in hours + 2)`, damped like HN's gravity formula so a fresh post with a few upvotes can't dominate; converges to raw points/hour as posts age.
- **Heat** — `comments / points`; 0-point rows (job posts) get a below-zero sentinel so they sink to the bottom instead of producing `Infinity`/`NaN`.

Plus: per-sort popup toggles (both on by default, synced), a three-tier responsive menu, and a hotkey-conflict note naming the intercepted keys.

## Behavior

- **Hotkeys** V and H join P/T/C/D; a disabled sort's key is inert (skipped before conflict detection).
- **Disable = gone, including its effect.** Disabling the active derived sort reverts to HN's default order. Validation lives in `useSettings` (`resolveActiveSort`) at the init read and both watchers, resolving unknown/disabled stored values to `default`, local-only (no write-back / ping-pong). This also removes the pre-existing crash when an unmapped variant arrives via cross-device sync (highlight path now guards).
- **Responsive tiers:** full names (wide) → single-letter labels (medium) → native `<select>` dropdown (mobile). The word↔letter breakpoint is count-aware — one media block per enabled-option count (4/5/6), keyed on a `data-sort-count` attribute on the panel root; the dropdown tier is a fixed `max-width: 600px` breakpoint.
- **Conflict note:** when another extension intercepts a sort key, a `role="status"` note names the specific keys (hidden in the dropdown tier).

## Verification

All Verification Contract gates green:

| Gate | Result |
|---|---|
| `bun run test` | ✅ 205 passing (AE1–AE4 covered) |
| `bun run test:integration` | ✅ selectors unchanged |
| `bun run lint` | ✅ clean |
| `bun run build` | ✅ compiles |

**Manual responsive walk-through** (run headless against real news.ycombinator.com with the built assets, real media queries):

```
== 6 options (both derived enabled) ==
w=1500  count=6  FULL-NAMES
w=1440  count=6  FULL-NAMES
w=1439  count=6  LETTERS
w=1000  count=6  LETTERS
w= 601  count=6  LETTERS
w= 600  count=6  DROPDOWN
w= 400  count=6  DROPDOWN

== AE5: 4 options at w=1400 (6-option menu shows LETTERS here) ==
w=1400  count=4  FULL-NAMES   → AE5 PASS ✅

== R5/R6: disable the active velocity sort mid-session ==
before: active=velocity velocityBtn=true
after : active=default  velocityBtn=false   → PASS ✅
```

Breakpoints calibrated against HN's header: 4→1280px, 5→1360px, 6→1440px; dropdown at 600px.

## Scope

Per the plan, marketing scripts (`scripts/generate-demo.ts`, `scripts/screenshots/constants.ts`) and `description.txt` are deferred to follow-up / release time.